### PR TITLE
fix: 修正插件命名和版本信息

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,18 +2,18 @@
   "name": "cadence-skills-marketplace",
   "description": "Cadence AI自动化开发流程 - 基于Claude Code Skills的多Agent协作系统",
   "owner": {
-    "name": "Cadence Team",
-    "email": "cadence@example.com"
+    "name": "michaelChe",
+    "email": "michaelChe956@gmail.com"
   },
   "plugins": [
     {
-      "name": "Cadence-skills",
+      "name": "cadence",
       "description": "基于Claude Code Skills的完整开发流程自动化框架，包含需求探索、技术设计、TDD开发、代码审查等8个核心节点",
-      "version": "2.4.0",
+      "version": "0.0.1",
       "source": "./",
       "author": {
-        "name": "Cadence Team",
-        "email": "cadence@example.com"
+        "name": "michaelChe",
+        "email": "michaelChe956@gmail.com"
       }
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
-  "name": "Cadence-skills",
+  "name": "cadence",
   "description": "AI自动化开发流程 - 基于Claude Code Skills的多Agent协作系统",
-  "version": "2.4.0",
+  "version": "0.0.1",
   "author": {
-    "name": "Cadence Team",
-    "email": "cadence@example.com"
+    "name": "michaelChe",
+    "email": "michaelChe956@gmail.com"
   },
   "homepage": "https://github.com/michaelChe956/Cadence-skills",
   "repository": "https://github.com/michaelChe956/Cadence-skills",


### PR DESCRIPTION
- 插件名称从 "Cadence-skills" 改为 "cadence"（小写）
  * 确保命令格式为 /cadence:init 而非 /Cadence-skills:init
  * 符合 Claude Code 插件命名规范

- 版本从 "2.4.0" 调整为 "0.0.1"
  * 项目处于初始开发阶段

- 更新作者信息
  * 作者：Cadence Team → michaelChe
  * 邮箱：cadence@example.com → michaelChe956@gmail.com

影响范围：
- plugin.json
- marketplace.json