### PR TITLE
fix: 修正 Skill 命名规范

### DIFF
--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cadence:init
+name: init
 description: "Initialize an existing project as a Cadence-managed project with automatic configuration of environment, rules, documentation structure, and tech stack."
 ---
 


### PR DESCRIPTION
- 移除 Skill name 中的命名空间前缀
  * cadence:init → init
  * 系统会自动组合 plugin name 和 skill name

原因：
- plugin.json 中的 name 字段提供命名空间（cadence）
- Skill 文件中的 name 字段不应重复命名空间
- 符合 Claude Code 插件规范（参考 superpowers）

影响：
- 修复 "Skill cadence:init cannot be used with Skill tool" 错误
- 确保 /cadence:init 命令可以正常工作