### PR TITLE
feat: 重写离线安装脚本 & 更新 README 适配双插件结构

### DIFF
--- a/.claude/plans/2026-04-03_计划文档_离线安装脚本重写_v1.0.md
+++ b/.claude/plans/2026-04-03_计划文档_离线安装脚本重写_v1.0.md
@@ -1,0 +1,35 @@
+# 离线安装脚本重写计划
+
+> 日期: 2026-04-03
+> 版本: v1.0
+> 状态: 已批准
+
+## 背景
+
+项目已拆分为 `cadence-init`（项目初始化）和 `cadence-workflow`（开发工作流）两个独立插件，共用一个 marketplace。现有的 `install-offline.sh` 和 `install-offline.bat` 脚本仍按旧的单插件结构编写，需要重写以适配新的目录结构。
+
+## 设计方案
+
+### 安装模式
+
+- 保持一个 marketplace（`cadence-skills-local`），内含两个插件
+- 安装路径不变：`~/.claude/plugins/marketplaces/cadence-skills-local/`
+
+### 更新内容
+
+1. **复制范围** — 排除 `.git`、`install-offline.*`，只复制有效文件
+2. **版本号** — 脚本升级到 v2.0
+3. **提示信息** — 完成提示中说明两个插件
+4. **hooks 权限** — 确保 `cadence-workflow/hooks/session-start` 有执行权限（macOS/Linux）
+
+### 不变的部分
+
+- 安装路径
+- `known_marketplaces.json` 注册逻辑
+- 支持双平台（.sh / .bat）
+
+## 实施任务
+
+1. 重写 `install-offline.sh`
+2. 重写 `install-offline.bat`
+3. 测试验证

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ sudo apt install claude-code
 
 ## 安装
 
+Cadence 由两个独立插件组成：
+
+| 插件 | 说明 |
+|------|------|
+| **cadence-init** | 项目初始化 — 环境检查、项目分析、规则配置、MCP 配置、Skill 创建 |
+| **cadence-workflow** | 开发工作流 — 完整/快速/探索流程、TDD、代码审查、进度追踪 |
+
 ### 方式 1: 通过插件市场安装（推荐）
 
 在 Claude Code 中，首先注册市场：
@@ -123,19 +130,20 @@ sudo apt install claude-code
 /plugin marketplace add michaelChe956/Cadence-skills
 ```
 
-然后从这个市场安装插件：
+然后分别安装两个插件：
 
 ```bash
-/plugin install cadence@cadence-skills-marketplace
+/plugin install cadence-init@cadence-skills-marketplace
+/plugin install cadence-workflow@cadence-skills-marketplace
 ```
 
-### 方式 2: 从源码安装
+> 两个插件可以独立安装。如果只需要项目初始化功能，安装 `cadence-init` 即可；如果只需要开发工作流，安装 `cadence-workflow` 即可。推荐同时安装以获得完整体验。
 
-如果你想从源代码安装，可以使用以下步骤：
+### 方式 2: 离线安装
+
+适用于无法访问 GitHub 或需要在内网环境部署的场景。
 
 #### 步骤 1: 获取项目代码
-
-你可以通过以下任意方式获取项目代码：
 
 **方式 A: 使用 Git 克隆（推荐）**
 ```bash
@@ -150,7 +158,7 @@ cd Cadence-skills
 
 #### 步骤 2: 运行安装脚本
 
-项目提供了跨平台安装脚本：
+项目提供了跨平台安装脚本（v2.0，已适配双插件结构）：
 
 **Linux/macOS**：
 ```bash
@@ -164,48 +172,48 @@ chmod +x install-offline.sh
 install-offline.bat
 ```
 
-安装脚本会自动将项目安装到 `~/.claude/plugins/marketplaces/cadence-skills-local/` 目录。
+安装脚本会自动完成：
+- 将 `cadence-init` 和 `cadence-workflow` 安装到 `~/.claude/plugins/marketplaces/cadence-skills-local/`
+- 配置 `known_marketplaces.json` 注册本地 marketplace
+- 设置 `cadence-workflow/hooks/session-start` 的执行权限（macOS/Linux）
 
 #### 步骤 3: 配置项目启用插件
 
-在需要使用 Cadence 插件的项目目录中，执行以下操作：
+在需要使用 Cadence 插件的项目目录中：
 
 1. **创建 `.claude/` 目录**：
 ```bash
 mkdir -p .claude
 ```
 
-2. **创建 `settings.json` 文件**：
-```bash
-# Linux/macOS
-touch .claude/settings.json
-
-# Windows
-type nul > .claude\settings.json
-```
-
-3. **复制以下内容到 `settings.json` 文件**：
+2. **创建 `settings.json` 并启用插件**：
 ```json
 {
   "enabledPlugins": {
-    "cadence@cadence-skills-local": true
+    "cadence-init@cadence-skills-local": true,
+    "cadence-workflow@cadence-skills-local": true
   }
 }
 ```
 
-完成以上步骤后，重启 Claude Code 即可在该项目中使用 Cadence 插件。
+完成后重启 Claude Code 即可使用。
 
 #### 步骤 4: 更新插件
 
-如果需要更新插件，重复步骤 1 到步骤 3。
+拉取最新代码后重新运行安装脚本即可：
+
+```bash
+git pull
+./install-offline.sh  # 或 install-offline.bat
+```
 
 ### 验证安装
 
-在你选择的平台中开始一个新会话，请求一些应该触发 Skill 的内容（例如，"帮我规划这个功能"或"让我们调试这个问题"）。助手应该自动调用相关的 Cadence Skills。
+开始一个新会话，请求一些应该触发 Skill 的内容（例如，"帮我规划这个功能"或"让我们调试这个问题"）。助手应该自动调用相关的 Cadence Skills。
 
-## 项目初始化
+## 项目初始化（cadence-init 插件）
 
-> **重要**：安装完成后，强烈建议执行以下初始化步骤，确保项目环境正确配置。
+> **重要**：安装完成后，强烈建议执行以下初始化步骤，确保项目环境正确配置。以下命令均来自 `cadence-init` 插件。
 
 ### 步骤 1：前置条件检查
 
@@ -222,20 +230,7 @@ type nul > .claude\settings.json
 - ✅ 自动安装缺失的工具
 - ✅ 引导您完成 serena 项目配置
 
-### 步骤 2：项目初始化
-
-执行 `/init` 命令，初始化项目环境：
-
-```bash
-/init
-```
-
-该命令会：
-- ✅ 检测项目类型和技术栈
-- ✅ 创建 `.claude/` 目录结构
-- ✅ 配置项目规则和模板
-
-### 步骤 3：项目分析
+### 步骤 2：项目分析
 
 执行 `/project-analysis` 命令，分析项目结构：
 
@@ -247,7 +242,7 @@ type nul > .claude\settings.json
 - ✅ 分析项目技术栈和依赖
 - ✅ 生成项目初始化分析摘要文档
 
-### 步骤 4：Claude Code 规则配置
+### 步骤 3：Claude Code 规则配置
 
 执行 `/rule-config` 命令，配置项目规则：
 
@@ -261,7 +256,7 @@ type nul > .claude\settings.json
 - ✅ 配置命名规则
 - ✅ 配置目录结构
 
-### 步骤 5：MCP 配置
+### 步骤 4：MCP 配置
 
 执行 `/mcp-configuration` 命令，配置 MCP：
 
@@ -273,7 +268,7 @@ type nul > .claude\settings.json
 - ✅ 创建 `.mcp.json` 配置文件
 - ✅ 配置 MCP 使用规则
 
-### 步骤 6（可选）：项目个性化规则
+### 步骤 5（可选）：项目个性化规则
 
 执行 `/project-rules-examples` 命令，创建项目个性化规则：
 
@@ -289,7 +284,7 @@ type nul > .claude\settings.json
 
 **完成后**，您的项目就准备好使用 Cadence 的完整工作流程了！
 
-## 基本工作流程
+## 基本工作流程（cadence-workflow 插件）
 
 Cadence 提供 3 种流程模式，适应不同的开发场景：
 
@@ -536,10 +531,20 @@ Skills 直接存储在这个仓库中。要贡献：
 
 ## 更新
 
-当你更新插件时，Skills 会自动更新：
+### 市场安装更新
 
 ```bash
-/plugin update cadence
+/plugin update cadence-init
+/plugin update cadence-workflow
+```
+
+### 离线安装更新
+
+拉取最新代码后重新运行安装脚本：
+
+```bash
+git pull
+./install-offline.sh  # 或 install-offline.bat
 ```
 
 ## 版本历史

--- a/install-offline.bat
+++ b/install-offline.bat
@@ -7,17 +7,19 @@ REM   双击运行 install-offline.bat
 REM   或在命令行中执行: install-offline.bat
 REM
 REM 作者: Cadence Team
-REM 版本: v1.1
+REM 版本: v2.0
 REM 更新记录:
+REM   v2.0 (2026-04-03): 适配拆分后的双插件 marketplace 结构 (cadence-init + cadence-workflow)
 REM   v1.1 (2025-03-17): 修复步骤4的 JSON 配置生成语法错误
 REM   v1.0: 初始版本
-REM ################################################################################
+REM ###############################################################################
 
 setlocal enabledelayedexpansion
 
 REM 打印横幅
 echo ============================================================
-echo   Cadence Skills 离线安装脚本 v1.1 (Windows)
+echo   Cadence Skills 离线安装脚本 v2.0 (Windows)
+echo   包含插件: cadence-init + cadence-workflow
 echo ============================================================
 echo.
 
@@ -43,8 +45,8 @@ if not exist "%MARKETPLACES_DIR%" (
 )
 echo.
 
-REM 步骤 2: 创建 cadence-skills-local 目录
-echo 🔨 步骤 2: 创建 cadence-skills-local 目录
+REM 步骤 2: 创建安装目录
+echo 🔨 步骤 2: 创建安装目录
 if not exist "%TARGET_DIR%" (
     mkdir "%TARGET_DIR%"
     echo   ✅ 已创建: %TARGET_DIR%
@@ -60,26 +62,41 @@ echo   📂 源目录: %SOURCE_DIR%
 echo   📂 目标目录: %TARGET_DIR%
 echo.
 
-REM 删除目标目录中的所有内容（准备覆盖）
+REM 清理目标目录中的旧文件
 if exist "%TARGET_DIR%" (
     echo   🗑️  清理旧文件...
     del /q "%TARGET_DIR%\*" 2>nul
     for /d %%p in ("%TARGET_DIR%\*") do rd /s /q "%%p" 2>nul
 )
 
-REM 复制所有文件（排除 .git 目录）
+REM 复制各目录和文件（排除 .git 和安装脚本）
 echo   📋 复制文件中...
-xcopy "%SOURCE_DIR%" "%TARGET_DIR%\" /E /I /Y /EXCLUDE:exclude.txt >nul 2>&1
 
-REM 如果 exclude.txt 不存在，使用备用方法
-if errorlevel 1 (
-    REM 复制所有文件
-    xcopy "%SOURCE_DIR%" "%TARGET_DIR%\" /E /I /Y >nul
+REM 复制 .claude-plugin 目录
+if exist "%SOURCE_DIR%\.claude-plugin" (
+    xcopy "%SOURCE_DIR%\.claude-plugin" "%TARGET_DIR%\.claude-plugin\" /E /I /Y >nul
+)
 
-    REM 删除 .git 目录
-    if exist "%TARGET_DIR%\.git" (
-        rd /s /q "%TARGET_DIR%\.git"
+REM 复制 cadence-init 插件
+if exist "%SOURCE_DIR%\cadence-init" (
+    xcopy "%SOURCE_DIR%\cadence-init" "%TARGET_DIR%\cadence-init\" /E /I /Y >nul
+)
+
+REM 复制 cadence-workflow 插件
+if exist "%SOURCE_DIR%\cadence-workflow" (
+    xcopy "%SOURCE_DIR%\cadence-workflow" "%TARGET_DIR%\cadence-workflow\" /E /I /Y >nul
+)
+
+REM 复制根目录文件
+for %%f in (CLAUDE.md README.md LICENSE .mcp.json) do (
+    if exist "%SOURCE_DIR%\%%f" (
+        copy /y "%SOURCE_DIR%\%%f" "%TARGET_DIR%\" >nul
     )
+)
+
+REM 复制 readmes 目录
+if exist "%SOURCE_DIR%\readmes" (
+    xcopy "%SOURCE_DIR%\readmes" "%TARGET_DIR%\readmes\" /E /I /Y >nul
 )
 
 echo.
@@ -87,7 +104,6 @@ echo   ✅ 复制完成
 echo.
 
 REM 步骤 4: 配置 known_marketplaces.json
-REM 修复：使用单行 PowerShell 命令避免批处理续行符问题 (v1.1)
 echo 🔨 步骤 4: 配置 known_marketplaces.json
 
 set "PLUGINS_DIR=%USERPROFILE%\.claude\plugins"
@@ -99,12 +115,7 @@ if not exist "%PLUGINS_DIR%" (
     echo   ✅ 已创建: %PLUGINS_DIR%
 )
 
-REM 使用单行 PowerShell 命令处理 JSON（统一处理创建和更新场景）
-REM 命令说明：
-REM   - 读取现有 JSON 文件（如果存在），否则创建空对象
-REM   - 检查是否已存在 cadence-skills-local 配置项
-REM   - 不存在则添加配置，存在则跳过（保留用户修改）
-REM   - 保存 JSON 文件
+REM 使用 PowerShell 处理 JSON
 powershell -Command "$f='%MARKETPLACES_FILE%'; $p='%TARGET_DIR:\=/%'; if(Test-Path $f){$j=Get-Content $f -Raw | ConvertFrom-Json}else{$j=@{}}; if($j.PSObject.Properties.Match('cadence-skills-local')){Write-Host '  ℹ️  cadence-skills-local 配置已存在，跳过更新'}else{$t=[DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.000Z'); $j | Add-Member -NotePropertyName 'cadence-skills-local' -NotePropertyValue @{source=@{source='github';repo='cadence/cadence-skills-local'};installLocation=$p;lastUpdated=$t} -Force; $j | ConvertTo-Json -Depth 10 | Out-File $f -Encoding UTF8; Write-Host '  ✅ 已添加 cadence-skills-local 配置'}"
 
 echo.
@@ -116,8 +127,12 @@ echo ============================================================
 echo.
 echo 📍 安装位置: %TARGET_DIR%
 echo.
+echo 📦 已安装插件:
+echo   - cadence-init: 项目初始化 (环境检查、项目分析、规则配置、MCP配置)
+echo   - cadence-workflow: 开发工作流 (完整流程、快速流程、探索流程、TDD等)
+echo.
 echo 💡 提示:
-echo   - 重启 Claude Code 以加载新安装的 skills
+echo   - 重启 Claude Code 以加载新安装的插件
 echo   - 使用 /cadence:* 命令访问 Cadence skills
 echo.
 

--- a/install-offline.sh
+++ b/install-offline.sh
@@ -7,7 +7,10 @@
 #   ./install-offline.sh
 #
 # 作者: Cadence Team
-# 版本: v1.0
+# 版本: v2.0
+# 更新记录:
+#   v2.0 (2026-04-03): 适配拆分后的双插件 marketplace 结构 (cadence-init + cadence-workflow)
+#   v1.0: 初始版本
 ################################################################################
 
 set -e  # 遇到错误立即退出
@@ -21,7 +24,8 @@ NC='\033[0m' # No Color
 
 # 打印横幅
 echo "============================================================"
-echo "  Cadence Skills 离线安装脚本 v1.0 (Linux/macOS)"
+echo "  Cadence Skills 离线安装脚本 v2.0 (Linux/macOS)"
+echo "  包含插件: cadence-init + cadence-workflow"
 echo "============================================================"
 echo ""
 
@@ -45,8 +49,8 @@ else
 fi
 echo ""
 
-# 步骤 2: 创建 cadence-skills-local 目录
-echo -e "${YELLOW}🔨 步骤 2:${NC} 创建 cadence-skills-local 目录"
+# 步骤 2: 创建目标目录
+echo -e "${YELLOW}🔨 步骤 2:${NC} 创建安装目录"
 if [ ! -d "$TARGET_DIR" ]; then
     mkdir -p "$TARGET_DIR"
     echo -e "  ${GREEN}✅ 已创建:${NC} $TARGET_DIR"
@@ -62,26 +66,40 @@ echo -e "  📂 源目录: $SOURCE_DIR"
 echo -e "  📂 目标目录: $TARGET_DIR"
 echo ""
 
-# 使用 rsync 或 cp 复制文件（排除 .git 目录）
 if command -v rsync &> /dev/null; then
-    # 优先使用 rsync（更快，显示进度）
     echo -e "  ${BLUE}使用 rsync 复制文件...${NC}"
-    rsync -av --exclude='.git' "$SOURCE_DIR/" "$TARGET_DIR/"
+    rsync -av \
+        --exclude='.git' \
+        --exclude='install-offline.sh' \
+        --exclude='install-offline.bat' \
+        "$SOURCE_DIR/" "$TARGET_DIR/"
 else
-    # 回退到 cp
     echo -e "  ${BLUE}使用 cp 复制文件...${NC}"
-    cp -r "$SOURCE_DIR/"* "$TARGET_DIR/" 2>/dev/null || true
-    cp -r "$SOURCE_DIR/."* "$TARGET_DIR/" 2>/dev/null || true
-    # 删除 .git 目录
-    rm -rf "$TARGET_DIR/.git"
+    # 复制主要目录和文件
+    for item in ".claude-plugin" "cadence-init" "cadence-workflow" "CLAUDE.md" "README.md" "LICENSE" ".mcp.json" "readmes"; do
+        if [ -e "$SOURCE_DIR/$item" ]; then
+            cp -r "$SOURCE_DIR/$item" "$TARGET_DIR/"
+        fi
+    done
 fi
 
 echo ""
 echo -e "  ${GREEN}✅ 复制完成${NC}"
 echo ""
 
-# 步骤 4: 配置 known_marketplaces.json
-echo -e "${YELLOW}🔨 步骤 4:${NC} 配置 known_marketplaces.json"
+# 步骤 4: 确保 hooks 脚本有执行权限
+echo -e "${YELLOW}🔨 步骤 4:${NC} 设置 hooks 执行权限"
+HOOK_SCRIPT="$TARGET_DIR/cadence-workflow/hooks/session-start"
+if [ -f "$HOOK_SCRIPT" ]; then
+    chmod +x "$HOOK_SCRIPT"
+    echo -e "  ${GREEN}✅ 已设置执行权限:${NC} cadence-workflow/hooks/session-start"
+else
+    echo -e "  ${YELLOW}⚠️  未找到 hooks 脚本:${NC} $HOOK_SCRIPT"
+fi
+echo ""
+
+# 步骤 5: 配置 known_marketplaces.json
+echo -e "${YELLOW}🔨 步骤 5:${NC} 配置 known_marketplaces.json"
 
 PLUGINS_DIR="$HOME/.claude/plugins"
 MARKETPLACES_FILE="$PLUGINS_DIR/known_marketplaces.json"
@@ -100,61 +118,46 @@ if [ ! -f "$MARKETPLACES_FILE" ]; then
     # 文件不存在，创建新文件
     echo -e "  ${BLUE}ℹ️  文件不存在，创建新文件${NC}"
 
-    cat > "$MARKETPLACES_FILE" << 'EOF'
+    cat > "$MARKETPLACES_FILE" << EOF
 {
   "cadence-skills-local": {
     "source": {
       "source": "github",
       "repo": "cadence/cadence-skills-local"
     },
-    "installLocation": "INSTALL_LOCATION_PLACEHOLDER",
-    "lastUpdated": "TIMESTAMP_PLACEHOLDER"
+    "installLocation": "$TARGET_DIR",
+    "lastUpdated": "$CURRENT_TIMESTAMP"
   }
 }
 EOF
 
-    # 替换占位符
-    sed -i.bak "s|INSTALL_LOCATION_PLACEHOLDER|$TARGET_DIR|g" "$MARKETPLACES_FILE"
-    sed -i.bak "s|TIMESTAMP_PLACEHOLDER|$CURRENT_TIMESTAMP|g" "$MARKETPLACES_FILE"
-    rm -f "${MARKETPLACES_FILE}.bak"
-
     echo -e "  ${GREEN}✅ 已创建配置文件${NC}"
 else
-    # 文件存在，追加或更新 cadence-skills-local 配置
+    # 文件存在，检查是否已存在配置
     echo -e "  ${BLUE}ℹ️  文件已存在，检查配置${NC}"
 
-    # 检查是否已存在 cadence-skills-local
     if grep -q '"cadence-skills-local"' "$MARKETPLACES_FILE"; then
-        echo -e "  ${BLUE}ℹ️  cadence-skills-local 配置已存在${NC}"
+        echo -e "  ${BLUE}ℹ️  cadence-skills-local 配置已存在，跳过更新${NC}"
     else
-        # 追加 cadence-skills-local 配置
+        # 追加配置
         echo -e "  ${BLUE}ℹ️  添加 cadence-skills-local 配置${NC}"
 
-        # 使用临时文件来安全地修改 JSON
         TEMP_FILE=$(mktemp)
-
-        # 读取文件内容，在最后一个 } 之前插入新配置
-        # 先找到最后一个 } 的位置
         LAST_BRACE_LINE=$(grep -n '^}$' "$MARKETPLACES_FILE" | tail -1 | cut -d: -f1)
 
         if [ -n "$LAST_BRACE_LINE" ]; then
-            # 在最后一个 } 之前插入配置
             head -n $((LAST_BRACE_LINE - 1)) "$MARKETPLACES_FILE" > "$TEMP_FILE"
 
-            # 检查倒数第二行是否已有逗号
+            # 确保前一项以逗号结尾
             SECOND_TO_LAST_LINE=$(head -n $((LAST_BRACE_LINE - 1)) "$MARKETPLACES_FILE" | tail -1)
             if [[ ! "$SECOND_TO_LAST_LINE" =~ ,$ ]]; then
-                # 如果没有逗号，需要添加
-                # 移除最后一行并添加逗号
                 TEMP_FILE2=$(mktemp)
-                # 使用 sed 删除最后一行（兼容 macOS 和 Linux）
                 sed '$d' "$TEMP_FILE" > "$TEMP_FILE2"
                 LAST_ENTRY=$(tail -1 "$TEMP_FILE")
                 echo "$LAST_ENTRY," >> "$TEMP_FILE2"
                 mv "$TEMP_FILE2" "$TEMP_FILE"
             fi
 
-            # 添加新配置
             cat >> "$TEMP_FILE" << EOF
   "cadence-skills-local": {
     "source": {
@@ -185,7 +188,11 @@ echo "============================================================"
 echo ""
 echo -e "📍 安装位置: $TARGET_DIR"
 echo ""
+echo -e "📦 已安装插件:"
+echo "  - cadence-init: 项目初始化 (环境检查、项目分析、规则配置、MCP配置)"
+echo "  - cadence-workflow: 开发工作流 (完整流程、快速流程、探索流程、TDD等)"
+echo ""
 echo "💡 提示:"
-echo "  - 重启 Claude Code 以加载新安装的 skills"
+echo "  - 重启 Claude Code 以加载新安装的插件"
 echo "  - 使用 /cadence:* 命令访问 Cadence skills"
 echo ""


### PR DESCRIPTION
## Summary

- 将 `install-offline.sh` 和 `install-offline.bat` 升级到 v2.0，适配拆分后的 `cadence-init` + `cadence-workflow` 双插件 marketplace 结构
- 更新 `README.md` 安装说明，反映双插件拆分（市场安装分别安装两个插件，离线安装一键安装两个插件）
- 项目初始化和工作流部分标注归属插件

## 变更详情

### install-offline.sh / .bat (v2.0)
- 精确控制复制范围，排除 `.git` 和安装脚本自身
- 新增步骤 4：确保 `cadence-workflow/hooks/session-start` 有执行权限（macOS/Linux）
- 完成提示列出两个插件的名称和功能
- `.sh` 使用 rsync `--exclude` 或 cp 逐项复制有效文件；`.bat` 逐项 xcopy，不再依赖 exclude.txt

### README.md
- 安装部分：新增插件对照表，市场安装命令拆分为两个插件，离线安装说明适配 v2.0 脚本
- `settings.json` 需启用 `cadence-init` 和 `cadence-workflow` 两个插件
- 项目初始化标题标注 `cadence-init` 插件，删除已不存在的 `/init` 步骤
- 工作流标题标注 `cadence-workflow` 插件
- 更新部分区分市场和离线两种更新方式

## Test plan

- [ ] 在 macOS 上执行 `./install-offline.sh`，验证安装目录结构正确
- [ ] 验证 `cadence-workflow/hooks/session-start` 有执行权限
- [ ] 验证 `known_marketplaces.json` 配置正确
- [ ] 在 Windows 上执行 `install-offline.bat`，验证安装正常（需 Windows 环境）
- [x] 检查 README 中的安装命令和说明准确

🤖 Generated with [Claude Code](https://claude.com/claude-code)