### PR TITLE
feat: add Codex MCP server sync to mcp-configuration command (Vibe Kanban)

### DIFF
--- a/.claude/designs/2026-04-10_方案设计_Codex-MCP-同步配置_v1.0.md
+++ b/.claude/designs/2026-04-10_方案设计_Codex-MCP-同步配置_v1.0.md
@@ -1,0 +1,163 @@
+# Codex MCP 同步配置方案设计
+
+## 概述
+
+在 `cadence-init:mcp-configuration` 命令中新增可选步骤，将 MCP 配置同步生成 Codex CLI 的 `.codex/config.toml` 格式，实现 Claude Code 和 Codex 共享相同的 MCP 服务器。
+
+## 背景
+
+- Claude Code 使用 `.mcp.json`（JSON 格式）配置 MCP 服务器
+- Codex CLI 使用 `.codex/config.toml`（TOML 格式）配置 MCP 服务器
+- 两者格式不同，无法直接复用，需要分别生成
+
+## 设计决策
+
+| 决策项 | 选择 | 理由 |
+|--------|------|------|
+| 配置作用域 | 项目级 `.codex/config.toml` | 和 `.mcp.json` 行为一致 |
+| 触发方式 | 现有命令的可选步骤 | 不是所有用户都用 Codex |
+| 模板方式 | 内嵌 TOML 模板 | 和现有 JSON 模板模式统一 |
+| .gitignore | 添加 `.codex/` | 包含本地路径和 API Key |
+| MiniMax | 保留不动 | 维持现有功能 |
+
+## 改动清单
+
+### 1. 命令文件 `cadence-init/commands/mcp-configuration.md`
+
+#### 1.1 检查清单新增第 6 步
+
+在现有第 5 步（配置 MiniMax MCP）之后新增：
+
+```
+6. **同步 MCP 配置到 Codex（可选）** — 询问用户是否将 MCP 配置同步为 Codex 的 `.codex/config.toml` 格式
+```
+
+原有第 6 步（配置 .gitignore）顺延为第 7 步。
+
+处理流程章节编号变化：
+
+| 原编号 | 原标题 | 新编号 | 标题 |
+|--------|--------|--------|------|
+| ### 5 | MCP 配置文件创建 | ### 5 | MCP 配置文件创建（不变） |
+| — | — | ### 6 | **同步 MCP 配置到 Codex（新增）** |
+| ### 6 | 配置 .gitignore | ### 7 | 配置 .gitignore（编号顺延） |
+
+#### 1.2 新增 section：### 6. 同步 MCP 配置到 Codex（可选）
+
+在"### 5. MCP 配置文件创建"之后、"### 6. 配置 .gitignore"（顺延为 ### 7）之前插入新 section。
+
+**流程**：
+
+1. `.mcp.json` 创建完成后，询问用户："是否将 MCP 配置同步到 Codex（生成 `.codex/config.toml`）？"
+2. 如果用户选择否：跳过
+3. 如果用户选择是：
+   - 检查 `.codex/config.toml` 是否已存在
+   - 根据检查结果处理（见下方"已存在文件处理"）
+   - 展示 API Key 安全提醒（与 `.mcp.json` 相同）
+   - 提醒用户：首次在 Codex 中打开项目时需确认信任项目，否则 `.codex/config.toml` 不会被加载
+
+**已存在文件处理**：
+
+| 场景 | 处理方式 |
+|------|---------|
+| `.codex/` 目录和 `config.toml` 均不存在 | 创建目录和文件，写入完整 TOML 内容 |
+| `.codex/config.toml` 已存在但不含 `[mcp_servers` | 保留原有内容，在文件末尾追加 MCP 配置 |
+| `.codex/config.toml` 已存在且含 `[mcp_servers` | 询问用户是否覆盖 MCP 配置部分 |
+
+**TOML 写入规则**：
+
+- 所有选中的 TOML 配置块（基础 + 智普可选 + MiniMax 可选）**合并写入同一个** `.codex/config.toml` 文件
+- `[mcp_servers]` 表头只写一次，放在文件开头（或追加内容的最前面）
+- 顺序：基础配置 → 智普配置（如果选中）→ MiniMax 配置（如果选中）
+
+#### 1.3 内嵌 TOML 模板
+
+**基础配置（必选）**：
+
+````toml
+[mcp_servers]
+
+[mcp_servers.time]
+command = "uvx"
+args = ["mcp-server-time", "--local-timezone=Asia/Shanghai"]
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+
+[mcp_servers.sequential-thinking]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+
+[mcp_servers.serena]
+command = "uvx"
+args = ["--from", "{{SERENA_PATH}}", "serena", "start-mcp-server", "--context", "ide-assistant", "--enable-web-dashboard", "false", "--enable-gui-log-window", "false"]
+````
+
+**智普 MCP 配置（可选）**：
+
+````toml
+[mcp_servers.zai-mcp-server]
+command = "npx"
+args = ["-y", "@z_ai/mcp-server"]
+env = { "Z_AI_API_KEY" = "your_zhipu_api_key", "Z_AI_MODE" = "ZHIPU" }
+
+[mcp_servers.web-search-prime]
+url = "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+
+[mcp_servers.web-reader]
+url = "https://open.bigmodel.cn/api/mcp/web_reader/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+
+[mcp_servers.zread]
+url = "https://open.bigmodel.cn/api/mcp/zread/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+````
+
+**MiniMax MCP 配置（可选）**：
+
+````toml
+[mcp_servers.MiniMax]
+command = "uvx"
+args = ["minimax-coding-plan-mcp", "-y"]
+env = { "MINIMAX_API_KEY" = "your_minimax_api_key", "MINIMAX_API_HOST" = "https://api.minimaxi.com" }
+````
+
+### 2. .gitignore 变更
+
+在"7. 配置 .gitignore"步骤中，添加 `.codex/`：
+
+```gitignore
+# Cadence 工作目录
+.serena/
+.worktrees/
+.mcp.json
+.codex/
+```
+
+同时在步骤说明表格中新增：
+
+| 目录/文件 | 说明 | 排除原因 |
+|----------|------|---------|
+| `.codex/` | Codex CLI 项目级配置 | 包含本地 MCP 路径和 API Key 占位符，不应提交 |
+
+## 格式差异对照
+
+| 特征 | Claude Code (`.mcp.json`) | Codex (`.codex/config.toml`) |
+|------|--------------------------|------------------------------|
+| 格式 | JSON | TOML |
+| 服务器定义 | `"mcpServers": { "name": {...} }` | `[mcp_servers.name]` |
+| 传输类型 | `"type": "stdio"` / `"type": "http"` | 隐式：有 `command` = stdio，有 `url` = http |
+| 环境变量 | `"env": { "KEY": "value" }` | `env = { "KEY" = "value" }` |
+| HTTP 头 | `"headers": { "Authorization": "..." }` | `http_headers = { "Authorization" = "..." }` |
+| HTTP 认证替代方案 | — | `bearer_token_env_var = "ENV_VAR"` 或 `env_http_headers = { "key" = "ENV_VAR" }`（从环境变量读取，更安全） |
+| type 字段 | 必须显式声明 | 不需要（自动推断） |
+
+## 不涉及的改动
+
+- MiniMax 相关内容保持不变
+- 智普相关内容保持不变
+- `.claude/rules/mcp-servers.md` 不需要修改（MCP 使用规则对两个工具通用）
+- `references/rules/mcp-servers.md` 模板不需要修改
+- `pre-check.md` 不需要修改

--- a/.claude/plans/2026-04-10_计划文档_Codex-MCP-同步配置_v1.0.md
+++ b/.claude/plans/2026-04-10_计划文档_Codex-MCP-同步配置_v1.0.md
@@ -1,0 +1,254 @@
+# Codex MCP 同步配置实施计划
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 `mcp-configuration` 命令中新增可选步骤，将 MCP 配置同步生成 Codex CLI 的 `.codex/config.toml` 格式。
+
+**Architecture:** 修改单个文件 `cadence-init/commands/mcp-configuration.md`，新增检查清单第 6 步、处理流程第 6 节（含 TOML 模板），并将原第 6 节顺延为第 7 节。同时在 .gitignore 步骤中添加 `.codex/`。
+
+**Tech Stack:** Markdown 文档编辑
+
+**Spec:** `.claude/designs/2026-04-10_方案设计_Codex-MCP-同步配置_v1.0.md`
+
+---
+
+## Chunk 1: 命令文件改动
+
+**Files:**
+- Modify: `cadence-init/commands/mcp-configuration.md`
+
+### Task 1: 检查清单新增第 6 步
+
+**Files:**
+- Modify: `cadence-init/commands/mcp-configuration.md:20` (第 20 行之后)
+
+- [ ] **Step 1: 在第 20 行后插入新步骤**
+
+在第 20 行 `5. **配置 MiniMax MCP（可选）** — 询问用户是否需要 MiniMax Token Plan MCP` 之后、第 21 行空行之前，插入：
+
+```markdown
+6. **同步 MCP 配置到 Codex（可选）** — 询问用户是否将 MCP 配置同步为 Codex 的 `.codex/config.toml` 格式
+```
+
+- [ ] **Step 2: 验证检查清单**
+
+确认检查清单现在为 7 步（原 5 步 + 新增第 6 步 + 原第 6 步变为第 7 步，但原第 6 步此时还没改编号，稍后处理）。
+
+等等——实际上检查清单中只有步骤描述没有编号标题，原文中步骤 3 的"配置 .gitignore"需要改为"7."的编号。但查看原文，检查清单中没有给 .gitignore 步骤编号。原文中步骤 3 是 `3. **配置 .gitignore**`，所以需要把第 3 步的 .gitignore 移到最后（第 7 位）。
+
+实际上再仔细看原文：
+
+```
+1. **添加 MCP 使用规则**
+2. **创建 MCP 配置文件**
+3. **配置 .gitignore**
+4. **配置智普 MCP（可选）**
+5. **配置 MiniMax MCP（可选）**
+```
+
+新的检查清单应该是：
+
+```
+1. **添加 MCP 使用规则**
+2. **创建 MCP 配置文件**
+3. **配置智普 MCP（可选）**
+4. **配置 MiniMax MCP（可选）**
+5. **同步 MCP 配置到 Codex（可选）**
+6. **配置 .gitignore**
+```
+
+- [ ] **Step 3: 重新排序检查清单**
+
+将第 16-20 行替换为：
+
+```markdown
+1. **添加 MCP 使用规则** — 添加各 MCP server 的使用规则到 CLAUDE.md
+2. **创建 MCP 配置文件** — 在项目根目录创建 `.mcp.json` 配置
+3. **配置智普 MCP（可选）** — 询问用户是否需要智普 AI 的四个专属 MCP
+4. **配置 MiniMax MCP（可选）** — 询问用户是否需要 MiniMax Token Plan MCP
+5. **同步 MCP 配置到 Codex（可选）** — 询问用户是否将 MCP 配置同步为 Codex 的 `.codex/config.toml` 格式
+6. **配置 .gitignore** — 添加 `.serena/`、`.worktrees/`、`.mcp.json` 和 `.codex/` 到 .gitignore
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cadence-init/commands/mcp-configuration.md
+git commit -m "feat: reorder mcp-configuration checklist and add Codex sync step"
+```
+
+---
+
+### Task 2: 新增处理流程第 6 节 — Codex MCP 配置同步
+
+**Files:**
+- Modify: `cadence-init/commands/mcp-configuration.md:472` (在 `### 6. 配置 .gitignore` 之前插入)
+
+- [ ] **Step 1: 在第 472 行之前插入新的 ### 6 节**
+
+在 `### 6. 配置 .gitignore` 之前（即第 471 行 ` ``` ` 之后、第 473 行 `### 6.` 之前），插入以下完整内容：
+
+```markdown
+### 6. 同步 MCP 配置到 Codex（可选）
+
+> **⚠️ 可选配置** — 添加前必须询问用户是否需要
+
+**用户确认**：
+- 在 `.mcp.json` 创建完成后，询问用户："是否将 MCP 配置同步到 Codex（生成 `.codex/config.toml`）？"
+- 如果不需要，跳过此步骤
+- 如果需要，根据下方模板生成 `.codex/config.toml`
+
+**已存在文件处理**：
+
+| 场景 | 处理方式 |
+|------|---------|
+| `.codex/` 目录和 `config.toml` 均不存在 | 创建目录和文件，写入完整 TOML 内容 |
+| `.codex/config.toml` 已存在但不含 `[mcp_servers` | 保留原有内容，在文件末尾追加 MCP 配置 |
+| `.codex/config.toml` 已存在且含 `[mcp_servers` | 询问用户是否覆盖 MCP 配置部分 |
+
+**TOML 写入规则**：
+- 所有选中的 TOML 配置块合并写入同一个 `.codex/config.toml` 文件
+- `[mcp_servers]` 表头只写一次，放在文件开头（或追加内容的最前面）
+- 写入顺序：基础配置 → 智普配置（如果选中）→ MiniMax 配置（如果选中）
+
+**Codex 与 Claude Code 格式差异**：
+
+| 特征 | Claude Code (`.mcp.json`) | Codex (`.codex/config.toml`) |
+|------|--------------------------|------------------------------|
+| 格式 | JSON | TOML |
+| 服务器定义 | `"mcpServers": { "name": {...} }` | `[mcp_servers.name]` |
+| 传输类型 | `"type": "stdio"` / `"type": "http"` | 隐式：有 `command` = stdio，有 `url` = http |
+| 环境变量 | `"env": { "KEY": "value" }` | `env = { "KEY" = "value" }` |
+| HTTP 头 | `"headers": { "Authorization": "..." }` | `http_headers = { "Authorization" = "..." }` |
+| type 字段 | 必须显式声明 | 不需要（自动推断） |
+
+**`{{SERENA_PATH}}` 替换规则与 `.mcp.json` 相同**。
+
+**信任提醒**：
+- 提醒用户：首次在 Codex 中打开项目时需确认信任项目，否则 `.codex/config.toml` 不会被加载
+
+**在项目根目录创建 `.codex/config.toml`**：
+
+#### 基础配置（必选）
+
+````toml
+[mcp_servers]
+
+[mcp_servers.time]
+command = "uvx"
+args = ["mcp-server-time", "--local-timezone=Asia/Shanghai"]
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+
+[mcp_servers.sequential-thinking]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+
+[mcp_servers.serena]
+command = "uvx"
+args = ["--from", "{{SERENA_PATH}}", "serena", "start-mcp-server", "--context", "ide-assistant", "--enable-web-dashboard", "false", "--enable-gui-log-window", "false"]
+````
+
+#### 智普 MCP 配置（可选 — 用户确认后添加）
+
+> 将以下配置合并到 `.codex/config.toml` 的 `[mcp_servers]` 中，`your_zhipu_api_key` 需用户自行替换
+
+````toml
+[mcp_servers.zai-mcp-server]
+command = "npx"
+args = ["-y", "@z_ai/mcp-server"]
+env = { "Z_AI_API_KEY" = "your_zhipu_api_key", "Z_AI_MODE" = "ZHIPU" }
+
+[mcp_servers.web-search-prime]
+url = "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+
+[mcp_servers.web-reader]
+url = "https://open.bigmodel.cn/api/mcp/web_reader/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+
+[mcp_servers.zread]
+url = "https://open.bigmodel.cn/api/mcp/zread/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+````
+
+#### MiniMax MCP 配置（可选 — 用户确认后添加）
+
+> 将以下配置合并到 `.codex/config.toml` 的 `[mcp_servers]` 中，`your_minimax_api_key` 需用户自行替换
+
+````toml
+[mcp_servers.MiniMax]
+command = "uvx"
+args = ["minimax-coding-plan-mcp", "-y"]
+env = { "MINIMAX_API_KEY" = "your_minimax_api_key", "MINIMAX_API_HOST" = "https://api.minimaxi.com" }
+````
+
+```
+
+- [ ] **Step 2: 验证插入位置正确**
+
+确认新的 `### 6. 同步 MCP 配置到 Codex（可选）` 在 `### 5. MCP 配置文件创建` 之后、`### 7. 配置 .gitignore` 之前。
+
+---
+
+### Task 3: 原第 6 节改为第 7 节 + .gitignore 添加 .codex/
+
+**Files:**
+- Modify: `cadence-init/commands/mcp-configuration.md` (原 `### 6. 配置 .gitignore` 区域)
+
+- [ ] **Step 1: 将 `### 6. 配置 .gitignore` 改为 `### 7. 配置 .gitignore`**
+
+将 `### 6. 配置 .gitignore` 替换为 `### 7. 配置 .gitignore`。
+
+- [ ] **Step 2: 在 .gitignore 内容中添加 `.codex/`**
+
+将两处 .gitignore 内容（已存在和新建两种情况）都添加 `.codex/`：
+
+```gitignore
+# Cadence 工作目录
+.serena/
+.worktrees/
+.mcp.json
+.codex/
+```
+
+即在第 493 行 `.mcp.json` 后和第 503 行 `.mcp.json` 后各添加一行 `.codex/`。
+
+- [ ] **Step 3: 在说明表格中添加 `.codex/` 行**
+
+在 .gitignore 说明表格中添加一行：
+
+```markdown
+| `.codex/` | Codex CLI 项目级配置 | 包含本地 MCP 路径和 API Key 占位符，不应提交 |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cadence-init/commands/mcp-configuration.md
+git commit -m "feat: add Codex MCP sync configuration and .codex/ to gitignore"
+```
+
+---
+
+### Task 4: 最终验证
+
+- [ ] **Step 1: 阅读完整文件验证结构**
+
+通读修改后的 `cadence-init/commands/mcp-configuration.md`，验证：
+
+1. 检查清单为 6 步，顺序正确
+2. 处理流程章节编号连续：1 → 4 → 5 → 6（新增 Codex）→ 7（.gitignore）
+3. TOML 模板格式正确（4 反引号外层 / 3 反引号内层）
+4. `{{SERENA_PATH}}` 占位符与 JSON 模板一致
+5. .gitignore 两处都包含 `.codex/`
+6. MiniMax 内容完整保留
+
+- [ ] **Step 2: Commit 最终状态**
+
+```bash
+git add cadence-init/commands/mcp-configuration.md
+git commit -m "docs: finalize Codex MCP sync configuration in mcp-configuration command"
+```

--- a/cadence-init/commands/mcp-configuration.md
+++ b/cadence-init/commands/mcp-configuration.md
@@ -15,9 +15,10 @@ description: "配置 MCP：创建 .mcp.json 配置文件和 MCP 使用规则"
 
 1. **添加 MCP 使用规则** — 添加各 MCP server 的使用规则到 CLAUDE.md
 2. **创建 MCP 配置文件** — 在项目根目录创建 `.mcp.json` 配置
-3. **配置 .gitignore** — 添加 `.serena/`、`.worktrees/` 和 `.mcp.json` 到 .gitignore
-4. **配置智普 MCP（可选）** — 询问用户是否需要智普 AI 的四个专属 MCP
-5. **配置 MiniMax MCP（可选）** — 询问用户是否需要 MiniMax Token Plan MCP
+3. **配置智普 MCP（可选）** — 询问用户是否需要智普 AI 的四个专属 MCP
+4. **配置 MiniMax MCP（可选）** — 询问用户是否需要 MiniMax Token Plan MCP
+5. **同步 MCP 配置到 Codex（可选）** — 询问用户是否将 MCP 配置同步为 Codex 的 `.codex/config.toml` 格式
+6. **配置 .gitignore** — 添加 `.serena/`、`.worktrees/`、`.mcp.json` 和 `.codex/` 到 .gitignore
 
 **下一步**：将配置结果传递给 @project-rules-examples skill 创建个性化规则示例
 

--- a/cadence-init/commands/mcp-configuration.md
+++ b/cadence-init/commands/mcp-configuration.md
@@ -471,7 +471,103 @@ MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-pla
 }
 ```
 
-### 6. 配置 .gitignore
+### 6. 同步 MCP 配置到 Codex（可选）
+
+> **⚠️ 可选配置** — 添加前必须询问用户是否需要
+
+**用户确认**：
+- 在 `.mcp.json` 创建完成后，询问用户："是否将 MCP 配置同步到 Codex（生成 `.codex/config.toml`）？"
+- 如果不需要，跳过此步骤
+- 如果需要，根据下方模板生成 `.codex/config.toml`
+
+**已存在文件处理**：
+
+| 场景 | 处理方式 |
+|------|---------|
+| `.codex/` 目录和 `config.toml` 均不存在 | 创建目录和文件，写入完整 TOML 内容 |
+| `.codex/config.toml` 已存在但不含 `[mcp_servers` | 保留原有内容，在文件末尾追加 MCP 配置 |
+| `.codex/config.toml` 已存在且含 `[mcp_servers` | 询问用户是否覆盖 MCP 配置部分 |
+
+**TOML 写入规则**：
+- 所有选中的 TOML 配置块合并写入同一个 `.codex/config.toml` 文件
+- `[mcp_servers]` 表头只写一次，放在文件开头（或追加内容的最前面）
+- 写入顺序：基础配置 → 智普配置（如果选中）→ MiniMax 配置（如果选中）
+
+**Codex 与 Claude Code 格式差异**：
+
+| 特征 | Claude Code (`.mcp.json`) | Codex (`.codex/config.toml`) |
+|------|--------------------------|------------------------------|
+| 格式 | JSON | TOML |
+| 服务器定义 | `"mcpServers": { "name": {...} }` | `[mcp_servers.name]` |
+| 传输类型 | `"type": "stdio"` / `"type": "http"` | 隐式：有 `command` = stdio，有 `url` = http |
+| 环境变量 | `"env": { "KEY": "value" }` | `env = { "KEY" = "value" }` |
+| HTTP 头 | `"headers": { "Authorization": "..." }` | `http_headers = { "Authorization" = "..." }` |
+| type 字段 | 必须显式声明 | 不需要（自动推断） |
+
+**`{{SERENA_PATH}}` 替换规则与 `.mcp.json` 相同**。
+
+**信任提醒**：
+- 提醒用户：首次在 Codex 中打开项目时需确认信任项目，否则 `.codex/config.toml` 不会被加载
+
+**在项目根目录创建 `.codex/config.toml`**：
+
+#### 基础配置（必选）
+
+````toml
+[mcp_servers]
+
+[mcp_servers.time]
+command = "uvx"
+args = ["mcp-server-time", "--local-timezone=Asia/Shanghai"]
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+
+[mcp_servers.sequential-thinking]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+
+[mcp_servers.serena]
+command = "uvx"
+args = ["--from", "{{SERENA_PATH}}", "serena", "start-mcp-server", "--context", "ide-assistant", "--enable-web-dashboard", "false", "--enable-gui-log-window", "false"]
+````
+
+#### 智普 MCP 配置（可选 — 用户确认后添加）
+
+> 将以下配置合并到 `.codex/config.toml` 的 `[mcp_servers]` 中，`your_zhipu_api_key` 需用户自行替换
+
+````toml
+[mcp_servers.zai-mcp-server]
+command = "npx"
+args = ["-y", "@z_ai/mcp-server"]
+env = { "Z_AI_API_KEY" = "your_zhipu_api_key", "Z_AI_MODE" = "ZHIPU" }
+
+[mcp_servers.web-search-prime]
+url = "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+
+[mcp_servers.web-reader]
+url = "https://open.bigmodel.cn/api/mcp/web_reader/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+
+[mcp_servers.zread]
+url = "https://open.bigmodel.cn/api/mcp/zread/mcp"
+http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
+````
+
+#### MiniMax MCP 配置（可选 — 用户确认后添加）
+
+> 将以下配置合并到 `.codex/config.toml` 的 `[mcp_servers]` 中，`your_minimax_api_key` 需用户自行替换
+
+````toml
+[mcp_servers.MiniMax]
+command = "uvx"
+args = ["minimax-coding-plan-mcp", "-y"]
+env = { "MINIMAX_API_KEY" = "your_minimax_api_key", "MINIMAX_API_HOST" = "https://api.minimaxi.com" }
+````
+
+### 7. 配置 .gitignore
 
 **目的**：将 Cadence 工作目录添加到 .gitignore，避免将临时文件和本地配置提交到版本控制。
 
@@ -492,6 +588,7 @@ ls -la .gitignore
 .serena/
 .worktrees/
 .mcp.json
+.codex/
 ```
 
 如果 `.gitignore` 不存在，创建文件并添加内容：
@@ -502,6 +599,7 @@ cat > .gitignore << 'EOF'
 .serena/
 .worktrees/
 .mcp.json
+.codex/
 EOF
 ```
 
@@ -512,6 +610,7 @@ EOF
 | `.serena/` | Serena MCP 本地记忆和会话数据 | 包含用户本地的会话记录和项目记忆，不应共享 |
 | `.worktrees/` | Git worktrees 隔离开发环境 | 包含临时的隔离开发环境，不应提交 |
 | `.mcp.json` | MCP 配置文件 | 包含本地 MCP 路径配置，不应提交到版本控制 |
+| `.codex/` | Codex CLI 项目级配置 | 包含本地 MCP 路径和 API Key 占位符，不应提交 |
 
 **验证**：
 


### PR DESCRIPTION
## Summary

- Add an optional step to the `/mcp-configuration` command that synchronizes MCP server configuration to Codex CLI's `.codex/config.toml` format, enabling Claude Code and Codex to share the same MCP servers.

## Changes

**Design & Planning:**
- Added design spec (`.claude/designs/`) and implementation plan (`.claude/plans/`) documenting the approach

**Command file (`cadence-init/commands/mcp-configuration.md`):**
- Reordered checklist: moved .gitignore to the end, added "同步 MCP 配置到 Codex" as optional step 5
- Added processing flow section `### 6. 同步 MCP 配置到 Codex（可选）` with:
  - TOML templates for base (time, context7, sequential-thinking, serena), ZhiPu (optional), and MiniMax (optional) MCP servers
  - Format difference table (JSON vs TOML) for reference
  - File-exists handling logic (create / append / ask-to-overwrite)
  - Codex project trust reminder
- Renumbered original `### 6. 配置 .gitignore` to `### 7`
- Added `.codex/` to both .gitignore templates and the explanation table

## Implementation Details

- Codex uses TOML format at `.codex/config.toml` (vs Claude Code's JSON `.mcp.json`)
- Key format differences: no explicit `type` field, `http_headers` instead of `headers`, inline `env = { ... }` syntax
- `{{SERENA_PATH}}` placeholder rules are shared between both formats
- `.codex/` added to `.gitignore` to prevent committing local paths and API key placeholders

---

This PR was written using [Vibe Kanban](https://vibekanban.com)