### PR TITLE
fix: Codex MCP 同步时排除 HTTP 类型的 MCP servers (Vibe Kanban)

### DIFF
--- a/cadence-init/commands/mcp-configuration.md
+++ b/cadence-init/commands/mcp-configuration.md
@@ -492,6 +492,7 @@ MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-pla
 - 所有选中的 TOML 配置块合并写入同一个 `.codex/config.toml` 文件
 - `[mcp_servers]` 表头只写一次，放在文件开头（或追加内容的最前面）
 - 写入顺序：基础配置 → 智普配置（如果选中）→ MiniMax 配置（如果选中）
+- **Codex 不支持 HTTP 类型 MCP** — 同步时必须排除所有 `"type": "http"` 的 MCP servers，仅同步 stdio 类型（有 `command` 字段）的服务
 
 **Codex 与 Claude Code 格式差异**：
 
@@ -537,23 +538,13 @@ args = ["--from", "{{SERENA_PATH}}", "serena", "start-mcp-server", "--context", 
 
 > 将以下配置合并到 `.codex/config.toml` 的 `[mcp_servers]` 中，`your_zhipu_api_key` 需用户自行替换
 
+> **⚠️ Codex 不支持 HTTP 类型的 MCP servers** — 智普的 `web-search-prime`、`web-reader`、`zread` 为 HTTP 类型，不会同步到 Codex。仅同步 stdio 类型的 `zai-mcp-server`。
+
 ````toml
 [mcp_servers.zai-mcp-server]
 command = "npx"
 args = ["-y", "@z_ai/mcp-server"]
 env = { "Z_AI_API_KEY" = "your_zhipu_api_key", "Z_AI_MODE" = "ZHIPU" }
-
-[mcp_servers.web-search-prime]
-url = "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"
-http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
-
-[mcp_servers.web-reader]
-url = "https://open.bigmodel.cn/api/mcp/web_reader/mcp"
-http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
-
-[mcp_servers.zread]
-url = "https://open.bigmodel.cn/api/mcp/zread/mcp"
-http_headers = { "Authorization" = "Bearer your_zhipu_api_key" }
 ````
 
 #### MiniMax MCP 配置（可选 — 用户确认后添加）

--- a/cadence-init/commands/mcp-configuration.md
+++ b/cadence-init/commands/mcp-configuration.md
@@ -500,7 +500,7 @@ MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-pla
 |------|--------------------------|------------------------------|
 | 格式 | JSON | TOML |
 | 服务器定义 | `"mcpServers": { "name": {...} }` | `[mcp_servers.name]` |
-| 传输类型 | `"type": "stdio"` / `"type": "http"` | 隐式：有 `command` = stdio，有 `url` = http |
+| 传输类型 | `"type": "stdio"` / `"type": "http"` | 仅 stdio（有 `command`），**HTTP 类型不支持** |
 | 环境变量 | `"env": { "KEY": "value" }` | `env = { "KEY" = "value" }` |
 | HTTP 头 | `"headers": { "Authorization": "..." }` | `http_headers = { "Authorization" = "..." }` |
 | type 字段 | 必须显式声明 | 不需要（自动推断） |


### PR DESCRIPTION
## Summary

- 修复 `mcp-configuration` 命令中 Codex MCP 同步逻辑：Codex 不支持 HTTP 类型的 MCP servers，同步到 `.codex/config.toml` 时不再包含 HTTP 类型的服务
- 从智普 MCP Codex TOML 模板中移除了 `web-search-prime`、`web-reader`、`zread` 三个 HTTP 类型的配置，仅保留 stdio 类型的 `zai-mcp-server`
- 更新格式差异表中传输类型描述，明确标注 Codex 不支持 HTTP 类型

## Changes

| 文件 | 变更内容 |
|------|---------|
| `cadence-init/commands/mcp-configuration.md` | TOML 写入规则新增 HTTP 排除规则 |
| 同上 | 智普 Codex TOML 模板移除 3 个 HTTP 类型 server |
| 同上 | 格式差异表传输类型行更新描述 |

## Why

Codex CLI 不支持 HTTP 传输类型的 MCP servers。此前同步逻辑会将智普的 `web-search-prime`、`web-reader`、`zread`（均为 HTTP 类型）写入 `.codex/config.toml`，导致 Codex 尝试连接不支持的服务。此 PR 确保同步时仅包含 stdio 类型的 MCP servers。

## Test plan

- [ ] 验证 `.codex/config.toml` 模板中不再包含 `url` 字段的服务
- [ ] 验证 `.mcp.json` 配置未受影响（Claude Code 仍支持 HTTP 类型）
- [ ] 验证格式差异表描述准确

---

This PR was written using [Vibe Kanban](https://vibekanban.com)