### PR TITLE
feat: add CodeGraph initialization support

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -14,7 +14,7 @@
 | `document-storage.md` | 文档存储规则（目录、命名、路径映射） |
 | `markdown-format.md` | Markdown 格式规则（代码块嵌套） |
 | `mcp-servers.md` | MCP Server 使用规则（所有 MCP 工具） |
-| `code-reading.md` | 代码阅读规则（ast-grep outline 使用规范） |
+| `code-reading.md` | 代码阅读规则（CodeGraph 与 ast-grep outline 使用规范） |
 | `playwright.md` | Playwright CLI 使用规则 |
 
 ## 修改权限

--- a/.claude/rules/code-reading.md
+++ b/.claude/rules/code-reading.md
@@ -4,9 +4,20 @@
 
 ### 核心原则
 
-- **优先使用 `ast-grep outline` 获取结构化大纲** - 在阅读、检索、理解代码时，必须优先使用 `ast-grep outline` 命令获取文件或目录的结构化大纲（函数、类、结构体、导入导出、成员及其源码区间），再基于大纲决定要精读哪一段，避免直接整文件盲读造成 token 浪费与上下文污染。
+- **大范围检索优先使用 CodeGraph** - 在架构理解、调用链分析、影响面分析、跨文件符号关系、功能流向追踪等场景中，优先使用 CodeGraph 或 `codegraph explore` 建立全局视图。
+- **精确结构阅读优先使用 `ast-grep outline`** - 在阅读、检索、理解具体文件或符号时，必须优先使用 `ast-grep outline` 命令获取文件或目录的结构化大纲（函数、类、结构体、导入导出、成员及其源码区间），再基于大纲决定要精读哪一段，避免直接整文件盲读造成 token 浪费与上下文污染。
 - **基于大纲定向精读** - 拿到大纲后，仅对真正需要的符号/区间做进一步阅读；先用 `--match` / `--view` 展开目标符号的签名或成员，再决定是否需要读取完整实现。
-- **检索代码时同样适用** - 查找“某个符号定义在哪”“某个模块导出了什么”“谁导入某个依赖”等结构化问题时，优先用 `ast-grep outline` 而非 `grep` 或整文件读取。
+- **冲突时以 `ast-grep outline` 为准** - 如果 CodeGraph 与 `ast-grep outline` 结果冲突，先以 `ast-grep outline` 的结构化大纲为准，再通过定向文件阅读确认。
+
+### CodeGraph 与 ast-grep 分工
+
+| 场景 | 优先工具 | 说明 |
+|------|----------|------|
+| 架构理解、调用链分析、影响面分析 | CodeGraph | 适合跨文件、跨模块的大范围检索 |
+| 功能从入口到落点的流向追踪 | CodeGraph | 先建立全局路径，再定向精读 |
+| 单文件结构阅读、导入导出查看 | `ast-grep outline` | 适合精确结构化定位 |
+| 类、函数、成员大纲查看 | `ast-grep outline` | 适合决定下一步精读范围 |
+| 两者结果冲突 | `ast-grep outline` | 以结构化大纲为准，再读目标源码确认 |
 
 ### 命令使用方式
 
@@ -38,6 +49,7 @@ ast-grep outline src --items imports --match ast-grep-core --view signatures
 
 ### 适用场景判断
 
+- ✅ **鼓励**：大范围理解代码库时先用 CodeGraph 建立架构和调用关系视图。
 - ✅ **鼓励**：理解陌生文件结构、定位符号定义、梳理模块导出/导入关系、决定下一步精读范围。
 - ✅ **鼓励**：在大型仓库中先用 outline 建立结构地图，再按需深入。
 - ⚠️ **需说明**：当目标文件极小（如十几行的配置/模块）或已明确需要完整实现时，可直接读取，但应说明跳过 outline 的原因。
@@ -46,4 +58,6 @@ ast-grep outline src --items imports --match ast-grep-core --view signatures
 ### 参考资源
 
 - 获取命令帮助：`ast-grep outline --help`
+- CodeGraph 项目初始化：`codegraph init`
+- CodeGraph 大范围检索：`codegraph explore`
 - 设计说明与背景：https://ast-grep.github.io/blog/ast-grep-outline.html#why-outline

--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -65,6 +65,36 @@
 }
 ```
 
+### CodeGraph MCP
+
+**用途**：基于项目代码图进行大范围代码检索、架构理解、调用链分析和影响面分析。
+
+**触发场景**：
+- 需要理解某个功能跨文件如何工作
+- 需要分析调用链、依赖关系或影响面
+- 需要进行大范围代码检索
+- 需要回答“某功能从入口到落点如何流转”
+
+**使用规则**：
+1. 项目必须先执行 `codegraph init`，存在 `.codegraph/` 后 CodeGraph MCP 才提供工具。
+2. 大范围检索优先使用 CodeGraph。
+3. 精确结构阅读优先使用 `ast-grep outline`。
+4. `ast-grep outline` 与 CodeGraph 结果冲突时，以 `ast-grep outline` 为准。
+
+**手动服务命令**：
+```bash
+codegraph serve --mcp
+```
+
+**典型工作流**：
+```
+# 大范围理解功能流向
+> 使用 CodeGraph 分析登录流程从入口到服务层的调用链
+
+# 影响面分析
+> 使用 CodeGraph 分析修改 UserService 会影响哪些模块
+```
+
 ### 智普视觉理解 MCP（可选）
 
 **用途**：图像分析、视频理解、UI 截图转代码、OCR 文字提取、错误截图诊断

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@
 - **浏览器自动化工具必须遵循项目规范** → 详见 `.claude/rules/playwright.md`
 
 ### 8. 代码阅读规则
-- **阅读代码时优先使用 ast-grep outline 获取结构化大纲** → 详见 `.claude/rules/code-reading.md`
+- **大范围检索使用 CodeGraph，精确结构阅读优先使用 ast-grep outline** → 详见 `.claude/rules/code-reading.md`
 
 ## 与 CLAUDE.md 的关系
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,6 @@
 - **浏览器自动化工具规范** → 详见 `.claude/rules/playwright.md`
 
 ### 8. 代码阅读规则
-- **结构化优先，使用 ast-grep outline 获取大纲再定向精读** → 详见 `.claude/rules/code-reading.md`
+- **大范围检索使用 CodeGraph，精确结构阅读优先使用 ast-grep outline** → 详见 `.claude/rules/code-reading.md`
 
 ## 项目信息

--- a/cadence-init/commands/mcp-configuration.md
+++ b/cadence-init/commands/mcp-configuration.md
@@ -330,6 +330,7 @@ MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-pla
 ### 5. MCP 配置文件创建
 **说明**：
 - 智普和 MiniMax MCP 为**可选配置**，根据用户选择决定是否包含
+- CodeGraph MCP 通常由 `rule-config` 执行 `codegraph install --target=claude,codex --location=local --yes` 自动配置；本节提供手动兜底配置
 
 **在项目根目录创建 `.mcp.json`**：
 
@@ -363,6 +364,24 @@ MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-pla
       ],
       "env": {}
     }
+  }
+}
+```
+
+#### CodeGraph MCP 配置（兜底 — rule-config 自动配置失败时添加）
+
+> 将以下配置合并到 `.mcp.json` 的 `mcpServers` 中。CodeGraph 需要先通过 `/pre-check` 安装，并在项目根目录执行过 `codegraph init`。
+
+```json
+{
+  "codegraph": {
+    "type": "stdio",
+    "command": "codegraph",
+    "args": [
+      "serve",
+      "--mcp"
+    ],
+    "env": {}
   }
 }
 ```
@@ -449,7 +468,7 @@ MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-pla
 **TOML 写入规则**：
 - 所有选中的 TOML 配置块合并写入同一个 `.codex/config.toml` 文件
 - `[mcp_servers]` 表头只写一次，放在文件开头（或追加内容的最前面）
-- 写入顺序：基础配置 → 智普配置（如果选中）→ MiniMax 配置（如果选中）
+- 写入顺序：基础配置 → CodeGraph 配置（如果启用） → 智普配置（如果选中）→ MiniMax 配置（如果选中）
 - **Codex 不支持 HTTP 类型 MCP** — 同步时必须排除所有 `"type": "http"` 的 MCP servers，仅同步 stdio 类型（有 `command` 字段）的服务
 
 **Codex 与 Claude Code 格式差异**：
@@ -484,6 +503,16 @@ args = ["-y", "@upstash/context7-mcp"]
 [mcp_servers.sequential-thinking]
 command = "npx"
 args = ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+````
+
+#### CodeGraph MCP 配置（兜底 — rule-config 自动配置失败时添加）
+
+> 将以下配置合并到 `.codex/config.toml` 的 `[mcp_servers]` 中。CodeGraph 是 stdio MCP，可同步到 Codex。
+
+````toml
+[mcp_servers.codegraph]
+command = "codegraph"
+args = ["serve", "--mcp"]
 ````
 
 #### 智普 MCP 配置（可选 — 用户确认后添加）

--- a/cadence-init/commands/pre-check.md
+++ b/cadence-init/commands/pre-check.md
@@ -5,6 +5,7 @@
 ## 使用场景
 
 - 首次使用 Cadence 前，确保环境正确配置
+- 已初始化项目升级新版 Cadence 后，增量补齐新增工具（如 codegraph）
 
 ## 功能
 
@@ -28,7 +29,12 @@
    - 自动安装缺失的 ast-grep
    - 用于 `ast-grep outline` 代码阅读规则
 
-5. **API Key 配置提醒（可选）** - 智普/MiniMax MCP 密钥
+5. **codegraph** - 代码图谱与大范围代码检索工具
+   - 检查是否全局安装 @colbymchenry/codegraph
+   - 自动安装缺失的 codegraph
+   - 用于 CodeGraph MCP、项目级代码图初始化和大范围检索
+
+6. **API Key 配置提醒（可选）** - 智普/MiniMax MCP 密钥
    - 询问用户是否需要智普 AI MCP（视觉理解/联网搜索/网页读取/开源仓库）
    - 询问用户是否需要 MiniMax Token Plan MCP（网络搜索/图片理解）
    - 提醒用户自行获取 API Key，不验证密钥有效性
@@ -98,13 +104,42 @@ ast-grep --version
 - **典型用法**：`ast-grep outline src/parser.ts`、`ast-grep outline src --items imports`
 - **与 rule-config 的关系**：`rule-config` 会为 Coding 项目配置 `code-reading.md` 规则，要求优先使用 `ast-grep outline`
 
+## CodeGraph 安装
+
+### 检查命令
+
+```bash
+# 检查 codegraph 是否已安装
+codegraph version
+```
+
+### 安装命令
+
+```bash
+# 全局安装 CodeGraph CLI
+npm i -g @colbymchenry/codegraph
+```
+
+### 验证安装
+
+```bash
+# 验证 codegraph 安装成功
+codegraph version
+```
+
+### 说明
+
+- **用途**：生成项目代码图，支持大范围代码检索、架构理解、调用链分析和影响面分析
+- **典型初始化**：`rule-config` 会在项目内执行 `codegraph install --target=claude,codex --location=local --yes` 与 `codegraph init`
+- **增量行为**：老项目重新运行 `/pre-check` 时，已安装工具会跳过，只会补装缺失的 codegraph
+
 ## 检查流程
 
 ```dot
-检查 npx → 检查 uvx → 检查 playwright-cli → 检查 ast-grep → API Key 提醒（可选） → 完成
+检查 npx → 检查 uvx → 检查 playwright-cli → 检查 ast-grep → 检查 codegraph → API Key 提醒（可选） → 完成
 ```
 
-**重要**：前四个步骤（npx、uvx、playwright-cli、ast-grep）必须完成，不允许跳过。第五步 API Key 提醒为可选。
+**重要**：前五个步骤（npx、uvx、playwright-cli、ast-grep、codegraph）必须完成，不允许跳过。第六步 API Key 提醒为可选。
 
 ## 增量运行
 
@@ -113,9 +148,10 @@ ast-grep --version
 - 已安装的工具会跳过安装，仅报告状态。
 - 缺失或未成功安装的工具会自动重新安装。
 - 不会重复安装已存在的 Playwright skills。
+- 不会重复安装已存在的 codegraph。
 
 适用场景：
-- 新版 Cadence 新增工具（如 `ast-grep`）后，老项目重新运行即可补齐。
+- 新版 Cadence 新增工具（如 `ast-grep`、`codegraph`）后，老项目重新运行即可补齐。
 - 之前某一步安装失败后环境问题已修复，重新运行会再次尝试。
 
 ## 输出
@@ -145,8 +181,9 @@ ast-grep --version
 ## 强制规则
 
 - 所有与用户的交互必须使用中文
-- 必须完成所有四个基础步骤（npx、uvx、playwright-cli、ast-grep）
+- 必须完成所有五个基础步骤（npx、uvx、playwright-cli、ast-grep、codegraph）
 - playwright-cli 安装失败必须提供手动安装命令
 - ast-grep 安装失败必须提供手动安装命令 `npm i @ast-grep/cli -g`
+- codegraph 安装失败必须提供手动安装命令 `npm i -g @colbymchenry/codegraph`
 - API Key 配置提醒为可选步骤，不验证密钥有效性
 - 安全提醒：不要将 API Key 直接告诉 Claude Code

--- a/cadence-init/commands/rule-config.md
+++ b/cadence-init/commands/rule-config.md
@@ -21,7 +21,8 @@ description: "配置 Claude Code 与 Codex 规则：创建 rules 规则文件、
 6. **历史产物迁移** — 检测旧 `.claude/` 产物目录，用户确认后迁移到 `cadence/`
 7. **cadence gitignore 决策** — 询问用户是否将 `cadence/` 加入 `.gitignore`，默认不忽略
 8. **代码阅读规则配置** — 配置 `ast-grep outline` 的使用规则（可选，Coding 项目默认建议启用）
-9. **Playwright Skills 规则配置** — 配置 Playwright CLI 的使用规则（可选）
+9. **CodeGraph 项目初始化** — 项目级安装 CodeGraph 到 Claude Code/Codex 并初始化 `.codegraph/`（可选，Coding 项目默认建议启用）
+10. **Playwright Skills 规则配置** — 配置 Playwright CLI 的使用规则（可选）
 
 **下一步**：将配置结果传递给 @mcp-configuration skill 进行 MCP 配置
 
@@ -75,7 +76,7 @@ description: "配置 Claude Code 与 Codex 规则：创建 rules 规则文件、
    如果匹配多个，验证每个路径下是否同时存在 `document-storage.md`，
    从通过验证的结果中取修改时间最新的。
 
-> **重要**：此模板根路径需在后续所有步骤中复用（包括步骤 8 的 code-reading.md 和步骤 9 的 playwright.md）。
+> **重要**：此模板根路径需在后续所有步骤中复用（包括步骤 8 的 code-reading.md 和步骤 10 的 playwright.md）。
 
 **步骤 1c：创建目标目录**
 
@@ -135,7 +136,7 @@ mkdir -p .claude/rules
 - 详见 `cadence/project-rules/README.md`
 
 ### 7. 代码阅读规则
-- **结构化优先，使用 `ast-grep outline` 避免盲读** → 详见 `.claude/rules/code-reading.md`
+- **大范围检索使用 CodeGraph，精确结构阅读优先使用 `ast-grep outline`** → 详见 `.claude/rules/code-reading.md`
 
 ## 项目信息
 # currentDate
@@ -146,7 +147,8 @@ Today's date is {当前日期}。
 - 规则 5（MCP Server）由 `mcp-configuration` command 添加，此处先写入引用行
 - 规则 6（项目个性化规则）由 `project-rules-examples` command 添加详细内容
 - 规则 7（代码阅读）由步骤 8 添加（如用户选择启用）
-- 规则 8（Playwright）由步骤 9 添加（如用户选择启用）
+- CodeGraph 项目初始化由步骤 9 执行（如用户选择启用）
+- 规则 8（Playwright）由步骤 10 添加（如用户选择启用）
 - 规则 2（代码使用规则）根据步骤 1a 的项目类型检测结果选择对应摘要行
 
 **参考 CLAUDE.md 同步添加 AGENTS.md**：
@@ -190,7 +192,7 @@ Today's date is {当前日期}。
 - 详见 `cadence/project-rules/README.md`
 
 ### 7. 代码阅读规则
-- **结构化优先，使用 `ast-grep outline` 避免盲读** → 详见 `.claude/rules/code-reading.md`
+- **大范围检索使用 CodeGraph，精确结构阅读优先使用 `ast-grep outline`** → 详见 `.claude/rules/code-reading.md`
 
 ### 8. Playwright CLI 使用规则
 - **浏览器自动化工具规范** → 详见 `.claude/rules/playwright.md`
@@ -392,7 +394,7 @@ grep -qxF 'cadence/' .gitignore 2>/dev/null || printf '\n# Cadence 产物目录\
 
 ```markdown
 ### 8. 代码阅读规则
-- **结构化优先，使用 `ast-grep outline` 避免盲读** → 详见 `.claude/rules/code-reading.md`
+- **大范围检索使用 CodeGraph，精确结构阅读优先使用 `ast-grep outline`** → 详见 `.claude/rules/code-reading.md`
 ```
 
 **用户确认**：
@@ -400,7 +402,71 @@ grep -qxF 'cadence/' .gitignore 2>/dev/null || printf '\n# Cadence 产物目录\
 - 对非 Coding 项目：默认跳过，仅提示“非 Coding 项目跳过代码阅读规则”。
 - 如果用户选择启用，写入 CLAUDE.md 和 AGENTS.md 前展示完整规则供确认。
 
-### 9. Playwright Skills 规则配置
+### 9. CodeGraph 项目初始化
+
+**检测条件**：
+- 项目为 **Coding 项目**（基于步骤 1a 检测结果）
+- 用户需要大范围代码检索、调用链分析、架构理解或影响面分析
+- 对 Coding 项目默认建议启用，非 Coding 项目默认跳过
+
+**前置条件**：
+- `/pre-check` 已完成 `codegraph` 安装检查
+- `codegraph version` 可输出版本号
+
+**用户确认**：
+- 对 Coding 项目：询问用户是否启用 CodeGraph 项目初始化，默认选项为“启用”。
+- 对非 Coding 项目：默认跳过，仅提示“非 Coding 项目跳过 CodeGraph 初始化”。
+- 如果用户手动要求启用，即使未检测到源代码，也允许继续执行。
+
+**项目级安装命令**：
+
+```bash
+codegraph install --target=claude,codex --location=local --yes
+```
+
+**初始化命令**：
+
+```bash
+codegraph init
+```
+
+**验证命令**：
+
+```bash
+test -d .codegraph && codegraph status
+```
+
+**配置范围**：
+- `--target=claude,codex`：只支持 Claude Code 和 Codex。
+- `--location=local`：只写入当前项目配置，不写入全局 Agent 配置。
+- `.codegraph/`：本地代码图索引目录，应加入 `.gitignore`。
+- `codegraph.json`：团队共享配置文件，不应加入 `.gitignore`。
+
+**已存在状态处理**：
+
+| 场景 | 行为 |
+|------|------|
+| `.codegraph/` 不存在 | 用户确认后执行 `codegraph install` 与 `codegraph init` |
+| `.codegraph/` 已存在 | 运行 `codegraph status`，报告已初始化，不重复 `codegraph init` |
+| Claude/Codex 已有 CodeGraph MCP server | 跳过，不重复写入 |
+| Claude/Codex 缺少 CodeGraph MCP server | 执行 `codegraph install --target=claude,codex --location=local --yes` 补齐 |
+| `codegraph install` 失败 | 提供 `mcp-configuration.md` 中的手动兜底配置 |
+| `codegraph init` 失败 | 提示用户确认项目语言、目录规模或是否需要配置 `codegraph.json` |
+
+**.gitignore 增量处理**：
+
+检查 `.gitignore` 是否已包含 `.codegraph/`：
+
+```bash
+grep -qxF '.codegraph/' .gitignore 2>/dev/null || printf '\n# CodeGraph 本地索引\n.codegraph/\n' >> .gitignore
+```
+
+**增量要求**：
+- `/rule-config` 重复运行时，只补齐缺失的 CodeGraph 规则、摘要、MCP 配置、`.codegraph/` 初始化和 `.gitignore` 项。
+- 不直接覆盖用户已经存在的规则文件或 Agent 配置。
+- 写入前向用户展示本次将新增或更新的内容清单。
+
+### 10. Playwright Skills 规则配置
 
 **检测条件**：
 - 用户需要浏览器自动化功能
@@ -433,6 +499,7 @@ grep -qxF 'cadence/' .gitignore 2>/dev/null || printf '\n# Cadence 产物目录\
 | 文件不存在 | 从模板根路径读取并创建 |
 | 文件已存在 | **不自动覆盖**，向用户展示差异并询问是否更新 |
 | 新增规则模板（如 `code-reading.md`） | 检测为缺失项，询问用户是否需要新增 |
+| 规则文件已存在但缺少 CodeGraph 段落 | 不自动覆盖，展示差异并询问是否追加 |
 
 **检测命令示例**：
 
@@ -465,6 +532,19 @@ done
 | 规则文件和摘要均已存在 | 视为已启用，仅检查完整性，不再询问 |
 | 规则文件或摘要缺失 | 作为新增可选项询问用户 |
 | 无法判断历史选择 | 默认按新增项询问 |
+
+### CodeGraph 增量处理
+
+对于 CodeGraph 项目初始化：
+
+| 场景 | 行为 |
+|------|------|
+| 老项目已执行过 `/rule-config`，但缺少 CodeGraph | 只补 CodeGraph 相关规则、摘要、MCP 配置、`.codegraph/` 初始化和 `.gitignore` |
+| `.codegraph/` 已存在 | 运行 `codegraph status` 并跳过初始化 |
+| `.codegraph/` 不存在 | 用户确认后执行 `codegraph init` |
+| Claude/Codex 已有 CodeGraph MCP server | 跳过，不重复写入 |
+| `.gitignore` 已有 `.codegraph/` | 跳过 |
+| `codegraph.json` 存在 | 保留，不加入 `.gitignore` |
 
 ### 建议
 

--- a/cadence-init/references/rules/README.md
+++ b/cadence-init/references/rules/README.md
@@ -14,7 +14,7 @@
 | `document-storage.md` | 文档存储规则（目录、命名、路径映射） |
 | `markdown-format.md` | Markdown 格式规则（代码块嵌套） |
 | `mcp-servers.md` | MCP Server 使用规则（所有 MCP 工具） |
-| `code-reading.md` | 代码阅读规则（ast-grep outline 使用规范） |
+| `code-reading.md` | 代码阅读规则（CodeGraph 与 ast-grep outline 使用规范） |
 | `playwright.md` | Playwright CLI 使用规则 |
 
 ## 修改权限

--- a/cadence-init/references/rules/code-reading.md
+++ b/cadence-init/references/rules/code-reading.md
@@ -4,9 +4,20 @@
 
 ### 核心原则
 
-- **优先使用 `ast-grep outline` 获取结构化大纲** - 在阅读、检索、理解代码时，必须优先使用 `ast-grep outline` 命令获取文件或目录的结构化大纲（函数、类、结构体、导入导出、成员及其源码区间），再基于大纲决定要精读哪一段，避免直接整文件盲读造成 token 浪费与上下文污染。
+- **大范围检索优先使用 CodeGraph** - 在架构理解、调用链分析、影响面分析、跨文件符号关系、功能流向追踪等场景中，优先使用 CodeGraph 或 `codegraph explore` 建立全局视图。
+- **精确结构阅读优先使用 `ast-grep outline`** - 在阅读、检索、理解具体文件或符号时，必须优先使用 `ast-grep outline` 命令获取文件或目录的结构化大纲（函数、类、结构体、导入导出、成员及其源码区间），再基于大纲决定要精读哪一段，避免直接整文件盲读造成 token 浪费与上下文污染。
 - **基于大纲定向精读** - 拿到大纲后，仅对真正需要的符号/区间做进一步阅读；先用 `--match` / `--view` 展开目标符号的签名或成员，再决定是否需要读取完整实现。
-- **检索代码时同样适用** - 查找“某个符号定义在哪”“某个模块导出了什么”“谁导入某个依赖”等结构化问题时，优先用 `ast-grep outline` 而非 `grep` 或整文件读取。
+- **冲突时以 `ast-grep outline` 为准** - 如果 CodeGraph 与 `ast-grep outline` 结果冲突，先以 `ast-grep outline` 的结构化大纲为准，再通过定向文件阅读确认。
+
+### CodeGraph 与 ast-grep 分工
+
+| 场景 | 优先工具 | 说明 |
+|------|----------|------|
+| 架构理解、调用链分析、影响面分析 | CodeGraph | 适合跨文件、跨模块的大范围检索 |
+| 功能从入口到落点的流向追踪 | CodeGraph | 先建立全局路径，再定向精读 |
+| 单文件结构阅读、导入导出查看 | `ast-grep outline` | 适合精确结构化定位 |
+| 类、函数、成员大纲查看 | `ast-grep outline` | 适合决定下一步精读范围 |
+| 两者结果冲突 | `ast-grep outline` | 以结构化大纲为准，再读目标源码确认 |
 
 ### 命令使用方式
 
@@ -38,6 +49,7 @@ ast-grep outline src --items imports --match ast-grep-core --view signatures
 
 ### 适用场景判断
 
+- ✅ **鼓励**：大范围理解代码库时先用 CodeGraph 建立架构和调用关系视图。
 - ✅ **鼓励**：理解陌生文件结构、定位符号定义、梳理模块导出/导入关系、决定下一步精读范围。
 - ✅ **鼓励**：在大型仓库中先用 outline 建立结构地图，再按需深入。
 - ⚠️ **需说明**：当目标文件极小（如十几行的配置/模块）或已明确需要完整实现时，可直接读取，但应说明跳过 outline 的原因。
@@ -46,4 +58,6 @@ ast-grep outline src --items imports --match ast-grep-core --view signatures
 ### 参考资源
 
 - 获取命令帮助：`ast-grep outline --help`
+- CodeGraph 项目初始化：`codegraph init`
+- CodeGraph 大范围检索：`codegraph explore`
 - 设计说明与背景：https://ast-grep.github.io/blog/ast-grep-outline.html#why-outline

--- a/cadence-init/references/rules/mcp-servers.md
+++ b/cadence-init/references/rules/mcp-servers.md
@@ -65,6 +65,36 @@
 }
 ```
 
+### CodeGraph MCP
+
+**用途**：基于项目代码图进行大范围代码检索、架构理解、调用链分析和影响面分析。
+
+**触发场景**：
+- 需要理解某个功能跨文件如何工作
+- 需要分析调用链、依赖关系或影响面
+- 需要进行大范围代码检索
+- 需要回答“某功能从入口到落点如何流转”
+
+**使用规则**：
+1. 项目必须先执行 `codegraph init`，存在 `.codegraph/` 后 CodeGraph MCP 才提供工具。
+2. 大范围检索优先使用 CodeGraph。
+3. 精确结构阅读优先使用 `ast-grep outline`。
+4. `ast-grep outline` 与 CodeGraph 结果冲突时，以 `ast-grep outline` 为准。
+
+**手动服务命令**：
+```bash
+codegraph serve --mcp
+```
+
+**典型工作流**：
+```
+# 大范围理解功能流向
+> 使用 CodeGraph 分析登录流程从入口到服务层的调用链
+
+# 影响面分析
+> 使用 CodeGraph 分析修改 UserService 会影响哪些模块
+```
+
 ### 智普视觉理解 MCP（可选）
 
 **用途**：图像分析、视频理解、UI 截图转代码、OCR 文字提取、错误截图诊断

--- a/cadence-init/skills/pre-check/SKILL.md
+++ b/cadence-init/skills/pre-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-check
-description: Use when setting up development environments or configuring npx/uvx tools. IMPORTANT - All user interactions MUST be in Chinese (中文) - triggers when tools need installation.
+description: Use when setting up development environments or incrementally configuring npx/uvx/playwright-cli/ast-grep/codegraph tools. IMPORTANT - All user interactions MUST be in Chinese (中文) - triggers when tools need installation.
 disable-model-invocation: true
 ---
 
@@ -14,7 +14,7 @@ disable-model-invocation: true
 
 **强制规则**：
 1. **所有交互必须使用中文** - 提示、错误消息、用户询问一律中文
-2. **必须完成所有四个基础检查** - 不允许跳过 npx/uvx/playwright-cli/ast-grep 任一步骤
+2. **必须完成所有五个基础检查** - 不允许跳过 npx/uvx/playwright-cli/ast-grep/codegraph 任一步骤
 3. **API Key 配置为可选步骤** - 询问用户是否需要智普/MiniMax MCP，仅做配置提醒
 
 ## 何时使用
@@ -37,9 +37,9 @@ digraph when_to_use {
 }
 ```
 
-**使用场景**：环境初始化、CI/CD 环境准备、新开发者环境搭建
+**使用场景**：环境初始化、CI/CD 环境准备、新开发者环境搭建、新版 Cadence 工具补齐
 
-**不适用场景**：工具已确认安装、仅需检查单个工具、非开发环境
+**不适用场景**：全部工具已确认安装、仅需检查单个工具、非开发环境
 
 ## 增量运行
 
@@ -47,6 +47,7 @@ digraph when_to_use {
 
 典型场景：
 - 框架新增 `ast-grep` 后，老项目重新运行 `/pre-check`，只会自动安装 `ast-grep`，不会影响已有的 `npx`、`uvx`、`playwright-cli`。
+- 框架新增 `codegraph` 后，老项目重新运行 `/pre-check`，只会自动安装 `codegraph`，不会影响已有的 `npx`、`uvx`、`playwright-cli`、`ast-grep`。
 - 某个工具安装失败后修复了环境问题，重新运行 `/pre-check` 会再次尝试安装该工具。
 
 ## 检查流程
@@ -78,7 +79,12 @@ digraph check_flow {
     install_ast_grep [label="安装 ast-grep"];
     ast_grep_done [label="ast-grep 就绪"];
 
-    // 步骤5（可选）
+    // 步骤5
+    check_codegraph [label="检查 codegraph", shape=diamond];
+    install_codegraph [label="安装 codegraph"];
+    codegraph_done [label="codegraph 就绪"];
+
+    // 步骤6（可选）
     ask_apikey [label="⚠️ 询问是否需要智普/MiniMax MCP", shape=diamond];
     remind_apikey [label="提醒获取 API Key\n并配置环境变量"];
     skip_apikey [label="跳过"];
@@ -101,9 +107,14 @@ digraph check_flow {
     playwright_done -> check_ast_grep;
 
     check_ast_grep -> install_ast_grep [label="未安装"];
-    check_ast_grep -> ask_apikey [label="已安装"];
+    check_ast_grep -> check_codegraph [label="已安装"];
     install_ast_grep -> ast_grep_done;
-    ast_grep_done -> ask_apikey;
+    ast_grep_done -> check_codegraph;
+
+    check_codegraph -> install_codegraph [label="未安装"];
+    check_codegraph -> ask_apikey [label="已安装"];
+    install_codegraph -> codegraph_done;
+    codegraph_done -> ask_apikey;
 
     ask_apikey -> remind_apikey [label="需要"];
     ask_apikey -> skip_apikey [label="不需要"];
@@ -120,7 +131,8 @@ digraph check_flow {
 | **2. uvx** | `uvx --version` | 输出版本号 | 自动安装稳定版本 |
 | **3. playwright-cli** | `playwright-cli --help` | 输出帮助信息 | 自动全局安装并安装 skills |
 | **4. ast-grep** | `ast-grep --version` | 输出版本号 | 自动全局安装 `@ast-grep/cli` |
-| **5. API Key（可选）** | 询问用户 | 用户确认已获取 | 跳过或提供获取地址 |
+| **5. codegraph** | `codegraph version` | 输出版本号 | 自动全局安装 `@colbymchenry/codegraph` |
+| **6. API Key（可选）** | 询问用户 | 用户确认已获取 | 跳过或提供获取地址 |
 
 ## 实施步骤
 
@@ -177,7 +189,27 @@ ast-grep --version
 npm i @ast-grep/cli -g
 ```
 
-### 步骤 5：API Key 配置提醒（可选）
+### 步骤 5：检查 codegraph
+
+```bash
+codegraph version
+```
+
+**行为（中文输出）**：
+- ✅ **已安装**：报告 "✓ codegraph 已安装（版本：{版本号}）"
+- ❌ **未安装**：报告 "正在安装 codegraph..."，执行 `npm i -g @colbymchenry/codegraph`，完成后报告 "✓ codegraph 安装成功"
+
+**安装命令**：
+
+```bash
+npm i -g @colbymchenry/codegraph
+```
+
+**增量要求**：
+- 如果老项目已完成 `/pre-check`，重新运行时必须跳过已安装工具，只补装缺失的 codegraph。
+- codegraph 安装后只验证 codegraph，不重新安装 npx/uvx/playwright-cli/ast-grep。
+
+### 步骤 6：API Key 配置提醒（可选）
 
 > **⚠️ 可选步骤** — 仅在用户需要智普/MiniMax MCP 时执行
 
@@ -211,3 +243,4 @@ npm i @ast-grep/cli -g
 | **uvx 安装失败** | Python/pip 不可用 | 先安装 Python |
 | **playwright-cli 安装失败** | Node.js/npm 不可用或网络问题 | 检查 Node.js 环境，或手动执行安装命令 |
 | **ast-grep 安装失败** | Node.js/npm 不可用或网络问题 | 检查 Node.js 环境，或手动执行 `npm i @ast-grep/cli -g` |
+| **codegraph 安装失败** | Node.js/npm 不可用或网络问题 | 检查 Node.js 环境，或手动执行 `npm i -g @colbymchenry/codegraph` |

--- a/cadence/designs/2026-06-29_方案设计_CodeGraph集成与Serena检查_v1.0.md
+++ b/cadence/designs/2026-06-29_方案设计_CodeGraph集成与Serena检查_v1.0.md
@@ -40,6 +40,7 @@ codegraph init
    - 精确检索、单文件结构阅读、符号大纲优先使用 `ast-grep outline`。
    - `ast-grep` 与 CodeGraph 结果冲突时，以 `ast-grep outline` 为准。
 5. 去掉当前项目 Serena MCP 使用的检查结论：`cadence-init/` 当前已无 Serena 残留。
+6. 明确 `/pre-check` 与 `/rule-config` 必须支持反复增量执行，老项目重新运行时只补齐新增能力，不重复安装、不覆盖已确认配置。
 
 ## 2. 参考文档结论
 
@@ -116,6 +117,7 @@ rg -n "serena|Serena|\\.serena|mcp__serena" cadence-init
 | `.codegraph/` | 加入 `.gitignore` | 该目录保存本地 SQLite 索引，不应提交 |
 | `codegraph.json` | 不加入 `.gitignore` | 这是可共享的项目配置文件，应允许团队提交 |
 | 与 `ast-grep` 的关系 | 大范围用 CodeGraph，精确结构用 `ast-grep outline` | 两者职责不同，冲突时以结构化大纲工具为准 |
+| 增量执行模型 | `/pre-check` 按工具粒度补齐；`/rule-config` 按规则/配置/初始化状态补齐 | 支持已初始化项目升级到新版 Cadence，例如只补 CodeGraph |
 
 ## 5. 改动范围
 
@@ -182,6 +184,38 @@ rg -n "serena|Serena|\\.serena|mcp__serena" cadence-init
 3. 检查流程更新为包含 CodeGraph。
 4. 强制规则新增 CodeGraph 安装失败手动命令。
 
+#### 6.1.4 增量行为定义
+
+`/pre-check` 不是一次性初始化命令，必须允许用户在已执行过 `/pre-check` 的项目中再次运行。
+
+典型场景：
+
+```text
+老项目已完成 npx / uvx / playwright-cli / ast-grep 检查
+        ↓
+Cadence 新版本增加 CodeGraph
+        ↓
+用户重新运行 /pre-check
+        ↓
+只检查并安装缺失的 CodeGraph，其他已安装工具直接跳过
+```
+
+执行规则：
+
+| 场景 | 行为 |
+|------|------|
+| 工具已安装 | 输出当前版本或已安装状态，跳过安装 |
+| 工具未安装 | 执行对应安装命令，安装后验证 |
+| 单个工具安装失败 | 报告该工具失败并给出手动命令，不重装其他已就绪工具 |
+| 重复运行 | 每个工具独立检查，结果不依赖是否首次运行 |
+| 新增工具上线 | 老项目重新运行 `/pre-check` 时只补齐新增工具 |
+
+对 CodeGraph 的增量要求：
+
+1. 如果 `codegraph version` 成功，报告 CodeGraph 已安装并跳过。
+2. 如果 `codegraph version` 失败，执行 `npm i -g @colbymchenry/codegraph`。
+3. 安装完成后只验证 CodeGraph，不重新安装其他工具。
+
 ### 6.2 `/rule-config` 增加 CodeGraph 初始化
 
 #### 6.2.1 新增步骤位置
@@ -246,6 +280,40 @@ codegraph.json
 ```
 
 原因：`codegraph.json` 用于排除已提交的大型目录、自定义扩展名、嵌套仓库等配置，属于团队可共享配置。
+
+#### 6.2.6 增量行为定义
+
+`/rule-config` 也必须支持在已初始化项目中反复运行，用于补齐新版 Cadence 新增的规则、配置和项目初始化步骤。
+
+典型场景：
+
+```text
+老项目已经生成 .claude/rules、CLAUDE.md、AGENTS.md
+        ↓
+Cadence 新版本增加 CodeGraph 规则与初始化
+        ↓
+用户重新运行 /rule-config
+        ↓
+只补 CodeGraph 相关规则、摘要、.gitignore 和项目初始化，不覆盖已有规则全文
+```
+
+执行规则：
+
+| 检查对象 | 已存在时 | 缺失时 |
+|----------|----------|--------|
+| `.claude/rules/code-reading.md` | 不自动覆盖，检查是否缺少 CodeGraph 段落并询问是否更新 | 从模板创建 |
+| `.claude/rules/mcp-servers.md` | 不自动覆盖，检查是否缺少 CodeGraph MCP 章节并询问是否追加 | 从模板创建 |
+| `CLAUDE.md` / `AGENTS.md` 摘要 | 已有 CodeGraph/代码阅读摘要则跳过 | 追加或更新对应摘要 |
+| `.codegraph/` | 视为已初始化，运行 `codegraph status` 报告状态 | 询问用户后执行 `codegraph init` |
+| Claude/Codex MCP 配置 | 已有 CodeGraph server 时跳过 | 通过 `codegraph install --target=claude,codex --location=local --yes` 补齐 |
+| `.gitignore` | 已含 `.codegraph/` 时跳过 | 追加 `.codegraph/` |
+
+覆盖原则：
+
+1. 不直接覆盖用户已经存在的规则文件。
+2. 如果模板内容发生变化，先展示差异或说明变更范围，再询问是否更新。
+3. 可自动追加明显缺失且低风险的条目，例如 `.gitignore` 中的 `.codegraph/`。
+4. 对 `CLAUDE.md` 和 `AGENTS.md` 只做摘要级补齐，避免重写用户手工维护内容。
 
 ### 6.3 MCP 配置同步
 
@@ -346,29 +414,69 @@ codegraph serve --mcp
 
 `AGENTS.md` 同步使用同样表述。
 
-## 7. 增量运行策略
+## 7. 增量运行策略（核心要求）
+
+`/pre-check` 与 `/rule-config` 必须按增量命令设计，而不是仅面向首次初始化。
+
+核心原则：
+
+1. **可重复执行**：用户可以在任意已初始化项目中再次运行命令。
+2. **只补缺失项**：新版 Cadence 新增能力后，老项目重新运行命令只补齐新增内容。
+3. **不破坏已有配置**：不重复安装已就绪工具，不覆盖用户已确认或手工修改的规则。
+4. **每项独立判断**：某一项失败不应导致其他已就绪项被重复处理。
+5. **执行前报告变更范围**：尤其是 `/rule-config`，写入前应告知本次会新增或更新哪些文件。
 
 ### 7.1 `/pre-check`
 
-重复运行时：
+`/pre-check` 的增量粒度是“工具”。每次运行都逐项检查工具状态。
 
 | 场景 | 行为 |
 |------|------|
+| 老项目已执行过 `/pre-check`，新版新增 CodeGraph | 重新运行后只补装 CodeGraph |
+| npx / uvx / playwright-cli / ast-grep 已安装 | 报告已安装并跳过 |
 | CodeGraph 已安装 | 报告版本并跳过安装 |
 | CodeGraph 未安装 | 执行 `npm i -g @colbymchenry/codegraph` |
 | 安装后验证失败 | 报告失败并给出手动安装命令 |
+| 重复运行多次 | 输出检查结果，不重复安装已存在工具 |
+
+用户体验示例：
+
+```text
+✓ npx 已安装，跳过
+✓ uvx 已安装，跳过
+✓ playwright-cli 已安装，跳过
+✓ ast-grep 已安装，跳过
+正在安装 CodeGraph...
+✓ CodeGraph 安装成功
+```
 
 ### 7.2 `/rule-config`
 
-重复运行时：
+`/rule-config` 的增量粒度是“规则文件、入口摘要、MCP 配置、项目初始化状态”。
 
 | 场景 | 行为 |
 |------|------|
+| 老项目已执行过 `/rule-config`，新版新增 CodeGraph | 重新运行后只补 CodeGraph 相关规则、摘要、MCP 配置和 `.codegraph/` 初始化 |
+| 基础规则文件已存在 | 不自动覆盖，仅检查是否需要追加 CodeGraph 段落 |
 | `.codegraph/` 已存在 | 报告已初始化，不重复 `codegraph init` |
 | `.codegraph/` 不存在 | 询问是否初始化 |
 | CodeGraph 规则文件已存在 | 检查摘要是否缺失，不自动覆盖规则全文 |
 | `CLAUDE.md` / `AGENTS.md` 已有 CodeGraph 标记片段 | 不重复写入 |
+| Codex/Claude 已有 CodeGraph MCP server | 跳过，不重复写入 |
 | `.gitignore` 已包含 `.codegraph/` | 跳过 |
+
+用户体验示例：
+
+```text
+检测到项目已存在 .claude/rules 与 AGENTS.md。
+本次仅发现缺失项：
+- CodeGraph 代码阅读规则段落
+- CodeGraph MCP 规则段落
+- .codegraph/ 本地索引目录
+- .gitignore 中的 .codegraph/
+
+确认后只写入上述缺失项，不覆盖已有规则文件。
+```
 
 ## 8. 实施步骤
 

--- a/cadence/designs/2026-06-29_方案设计_CodeGraph集成与Serena检查_v1.0.md
+++ b/cadence/designs/2026-06-29_方案设计_CodeGraph集成与Serena检查_v1.0.md
@@ -1,0 +1,447 @@
+# CodeGraph 集成与 Serena 检查方案设计
+
+> 日期：2026-06-29 | 版本：v1.0 | 状态：待实施
+
+## 1. 背景与目标
+
+### 1.1 背景
+
+当前 `cadence-init` 已完成上一轮环境与规则改造：
+
+1. `/pre-check` 已去掉 Serena，并已增加 `ast-grep` 检查与安装。
+2. `/rule-config` 已增加 `code-reading.md` 规则模板，并能同步生成 `CLAUDE.md` 与 `AGENTS.md` 摘要引用。
+3. `/mcp-configuration` 已支持将 MCP 配置同步到 Codex 的 `.codex/config.toml`。
+
+本次需求是在现有基础上引入 CodeGraph：
+
+1. `/pre-check` 增加 CodeGraph 安装。
+2. `/rule-config` 增加 CodeGraph 的项目化初始化。
+3. 同步 Claude Code 与 Codex 的规则、MCP 配置和使用限制。
+4. 确认 `cadence-skills init` 中是否仍有 Serena 使用。
+
+### 1.2 目标
+
+1. 在 `/pre-check` 中增加 CodeGraph 检查、安装、验证流程，安装命令固定为：
+
+```bash
+npm i -g @colbymchenry/codegraph
+```
+
+2. 在 `/rule-config` 中增加 CodeGraph 项目级初始化：
+
+```bash
+codegraph install --target=claude,codex --location=local --yes
+codegraph init
+```
+
+3. 只支持 Claude Code 和 Codex，且只进行当前项目安装，不写入全局 Agent 配置。
+4. 增加代码检索规则：
+   - 大范围检索、架构理解、调用链、影响面分析优先使用 CodeGraph。
+   - 精确检索、单文件结构阅读、符号大纲优先使用 `ast-grep outline`。
+   - `ast-grep` 与 CodeGraph 结果冲突时，以 `ast-grep outline` 为准。
+5. 去掉当前项目 Serena MCP 使用的检查结论：`cadence-init/` 当前已无 Serena 残留。
+
+## 2. 参考文档结论
+
+| 文档 | 结论 |
+|------|------|
+| CodeGraph Quickstart | `npm i -g @colbymchenry/codegraph` 可安装 CLI；`codegraph install` 只接入 Agent，不索引代码；`codegraph init` 创建 `.codegraph/` 并建图 |
+| CodeGraph Installation | `codegraph install` 支持 `--target`、`--location`、`--yes`；`--location=local` 表示项目级安装 |
+| CodeGraph Configuration | 项目数据存放在项目根目录 `.codegraph/`；可选 `codegraph.json` 用于团队共享配置 |
+| CodeGraph MCP Server | MCP 服务命令为 `codegraph serve --mcp`；默认工具为 `codegraph_explore` |
+| CodeGraph CLI | `codegraph version` 可用于版本验证；`codegraph explore` 是 `codegraph_explore` MCP 工具的 CLI 等价入口 |
+
+参考链接：
+
+- <https://colbymchenry.github.io/codegraph/getting-started/quickstart/>
+- <https://colbymchenry.github.io/codegraph/getting-started/installation/>
+- <https://colbymchenry.github.io/codegraph/getting-started/configuration/>
+- <https://colbymchenry.github.io/codegraph/reference/mcp-server/>
+- <https://colbymchenry.github.io/codegraph/reference/cli/>
+
+## 3. 当前项目进度
+
+### 3.1 Worktree 状态
+
+| 项 | 状态 |
+|----|------|
+| 工作目录 | `.worktrees/feat-b-0629` |
+| 分支 | `feat-b-0629` |
+| 远端 | 已推送并跟踪 `origin/feat-b-0629` |
+| OpenSpec | 仅存在 `openspec/config.yaml`，无 `openspec/changes` 目录 |
+| 当前改动 | 写入本方案前无未提交改动 |
+
+### 3.2 已完成基础
+
+| 模块 | 当前状态 |
+|------|----------|
+| `cadence-init/skills/pre-check/SKILL.md` | 已包含 `npx`、`uvx`、`playwright-cli`、`ast-grep` 四项基础检查 |
+| `cadence-init/commands/pre-check.md` | 已包含 `ast-grep` 安装章节 |
+| `cadence-init/commands/rule-config.md` | 已包含 `code-reading.md` 配置、`CLAUDE.md` 与 `AGENTS.md` 同步 |
+| `cadence-init/references/rules/code-reading.md` | 已存在 `ast-grep outline` 代码阅读规则 |
+| `cadence-init/commands/mcp-configuration.md` | 已支持 Codex `.codex/config.toml` 同步 |
+| `cadence-init/references/rules/mcp-servers.md` | 已无 Serena MCP 章节 |
+
+### 3.3 Serena 检查结论
+
+在 `cadence-init/` 范围内执行以下检索：
+
+```bash
+rg -n "serena|Serena|\\.serena|mcp__serena" cadence-init
+```
+
+结果为空。
+
+结论：`cadence-skills init` 当前没有 Serena 使用残留。
+
+仍存在 Serena 的范围：
+
+| 范围 | 状态 | 本次处理建议 |
+|------|------|--------------|
+| `cadence-workflow/skills/` | 多个 workflow skill 仍依赖 Serena memory 或 Serena MCP 文案 | 不纳入本次 CodeGraph 初始化改造 |
+| `cadence-workflow/commands/` | 部分 command 文档仍提及 Serena | 不纳入本次 CodeGraph 初始化改造 |
+| `readmes/skills/` | 多篇说明文档仍提及 Serena | 后续按 workflow 去 Serena 独立处理 |
+| `cadence/plans/`、`cadence/docs/`、`cadence/designs/`、`cadence/analysis/` | 历史文档提及 Serena | 保留历史记录，不修改 |
+
+## 4. 设计决策
+
+| 决策项 | 选择 | 理由 |
+|--------|------|------|
+| 安装方式 | `npm i -g @colbymchenry/codegraph` | 用户明确指定，且官方支持 npm 全局安装 |
+| 版本检查命令 | `codegraph version` | 官方 CLI 文档列出该命令，并支持 `--version` |
+| Agent 接入方式 | `codegraph install --target=claude,codex --location=local --yes` | 精确限定 Claude Code 与 Codex，且只写当前项目配置 |
+| 项目初始化方式 | `codegraph init` | 官方定义为创建 `.codegraph/` 并构建完整图 |
+| MCP 配置主路径 | 优先使用 `codegraph install` 自动写入 | 避免手写配置与官方安装器行为不一致 |
+| MCP 配置兜底 | 在 `mcp-configuration.md` 中提供手动配置片段 | 便于安装器失败或需要人工修复时处理 |
+| `.codegraph/` | 加入 `.gitignore` | 该目录保存本地 SQLite 索引，不应提交 |
+| `codegraph.json` | 不加入 `.gitignore` | 这是可共享的项目配置文件，应允许团队提交 |
+| 与 `ast-grep` 的关系 | 大范围用 CodeGraph，精确结构用 `ast-grep outline` | 两者职责不同，冲突时以结构化大纲工具为准 |
+
+## 5. 改动范围
+
+| 操作 | 文件 |
+|------|------|
+| 修改 | `cadence-init/skills/pre-check/SKILL.md` |
+| 修改 | `cadence-init/commands/pre-check.md` |
+| 修改 | `cadence-init/commands/rule-config.md` |
+| 修改 | `cadence-init/commands/mcp-configuration.md` |
+| 修改 | `cadence-init/references/rules/code-reading.md` |
+| 修改 | `cadence-init/references/rules/mcp-servers.md` |
+| 修改 | `.claude/rules/code-reading.md` |
+| 修改 | `.claude/rules/mcp-servers.md` |
+| 修改 | `CLAUDE.md` |
+| 修改 | `AGENTS.md` |
+
+不纳入本次范围：
+
+1. 不重构 `cadence-workflow/skills/` 中的 Serena memory 体系。
+2. 不批量修改 `readmes/skills/` 的 Serena 历史说明。
+3. 不修改历史方案、计划、分析文档中的 Serena 记录。
+
+## 6. 详细设计
+
+### 6.1 `/pre-check` 增加 CodeGraph
+
+#### 6.1.1 检查流程调整
+
+当前基础检查为：
+
+```text
+检查 npx → 检查 uvx → 检查 playwright-cli → 检查 ast-grep → API Key 提醒（可选） → 完成
+```
+
+调整为：
+
+```text
+检查 npx → 检查 uvx → 检查 playwright-cli → 检查 ast-grep → 检查 codegraph → API Key 提醒（可选） → 完成
+```
+
+#### 6.1.2 命令定义
+
+| 阶段 | 命令 | 成功标志 | 失败处理 |
+|------|------|----------|----------|
+| 检查 | `codegraph version` | 输出版本号 | 执行安装 |
+| 安装 | `npm i -g @colbymchenry/codegraph` | npm 命令成功退出 | 提示用户手动执行安装命令 |
+| 验证 | `codegraph version` | 输出版本号 | 报告 CodeGraph 安装失败 |
+
+#### 6.1.3 文档调整点
+
+`cadence-init/skills/pre-check/SKILL.md`：
+
+1. 强制规则从“四个基础检查”改为“五个基础检查”。
+2. 流程图在 `check_ast_grep` 后增加 `check_codegraph`。
+3. 快速参考表增加 CodeGraph 行。
+4. 实施步骤增加“步骤 5：检查 CodeGraph”，API Key 顺延为步骤 6。
+5. 常见错误表增加 CodeGraph 安装失败处理。
+6. 增量运行章节增加“框架新增 CodeGraph 后，老项目重新运行 `/pre-check` 只补齐 CodeGraph”。
+
+`cadence-init/commands/pre-check.md`：
+
+1. 功能列表新增 CodeGraph。
+2. 新增“CodeGraph 安装”章节。
+3. 检查流程更新为包含 CodeGraph。
+4. 强制规则新增 CodeGraph 安装失败手动命令。
+
+### 6.2 `/rule-config` 增加 CodeGraph 初始化
+
+#### 6.2.1 新增步骤位置
+
+建议在现有“代码阅读规则配置”之后、“Playwright Skills 规则配置”之前增加 CodeGraph 初始化步骤。
+
+调整后的后半段流程：
+
+```text
+7. cadence gitignore 决策
+8. 代码阅读规则配置
+9. CodeGraph 项目初始化
+10. Playwright Skills 规则配置
+```
+
+#### 6.2.2 启用条件
+
+| 项目类型 | 默认行为 |
+|----------|----------|
+| Coding 项目 | 默认建议启用 CodeGraph |
+| 非 Coding 项目 | 默认跳过，仅提示“非 Coding 项目默认跳过 CodeGraph 初始化” |
+| 用户手动要求 | 即使未检测到源代码，也可启用 |
+
+#### 6.2.3 初始化命令
+
+在用户确认启用后，于项目根目录执行：
+
+```bash
+codegraph install --target=claude,codex --location=local --yes
+codegraph init
+```
+
+执行后验证：
+
+```bash
+test -d .codegraph && codegraph status
+```
+
+#### 6.2.4 已存在状态处理
+
+| 场景 | 行为 |
+|------|------|
+| `.codegraph/` 不存在 | 执行完整初始化 |
+| `.codegraph/` 已存在 | 运行 `codegraph status`，报告已初始化 |
+| Agent 配置已存在 | 不覆盖用户配置，报告已有配置并保留 |
+| `codegraph install` 失败 | 提供手动配置兜底方案 |
+| `codegraph init` 失败 | 提示用户确认项目是否包含 CodeGraph 支持的语言或是否需排除大型目录 |
+
+#### 6.2.5 `.gitignore` 规则
+
+如果启用 CodeGraph，应确保 `.gitignore` 包含：
+
+```gitignore
+# CodeGraph 本地索引
+.codegraph/
+```
+
+不应忽略：
+
+```gitignore
+codegraph.json
+```
+
+原因：`codegraph.json` 用于排除已提交的大型目录、自定义扩展名、嵌套仓库等配置，属于团队可共享配置。
+
+### 6.3 MCP 配置同步
+
+#### 6.3.1 主路径
+
+`/rule-config` 中通过以下命令完成 Claude Code 和 Codex 的项目级接入：
+
+```bash
+codegraph install --target=claude,codex --location=local --yes
+```
+
+该命令会按官方安装器逻辑写入对应 Agent 配置与指令片段。
+
+#### 6.3.2 兜底手动配置
+
+在 `cadence-init/commands/mcp-configuration.md` 中补充 CodeGraph 手动配置说明，供安装器失败或用户需要人工修复时使用。
+
+Claude Code `.mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "codegraph",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}
+```
+
+Codex `.codex/config.toml`：
+
+```toml
+[mcp_servers.codegraph]
+command = "codegraph"
+args = ["serve", "--mcp"]
+```
+
+#### 6.3.3 Codex 同步规则
+
+1. CodeGraph 是 stdio MCP，可同步到 Codex。
+2. 同步时不需要 HTTP 特殊处理。
+3. 如果 `.codex/config.toml` 已有 `[mcp_servers.codegraph]`，不自动覆盖，先询问用户。
+4. `.codex/` 仍保持 `.gitignore`，因为该目录可能包含本地配置和 API Key 占位符。
+
+### 6.4 规则文件同步
+
+#### 6.4.1 `code-reading.md` 新规则
+
+在 `cadence-init/references/rules/code-reading.md` 与 `.claude/rules/code-reading.md` 中增加 CodeGraph 与 `ast-grep` 的职责边界：
+
+```markdown
+### CodeGraph 与 ast-grep 分工
+
+- **大范围检索优先使用 CodeGraph**：架构理解、调用链分析、影响面分析、跨文件符号关系、功能流向追踪等场景，优先使用 CodeGraph 或 `codegraph explore`。
+- **精确检索优先使用 `ast-grep outline`**：单文件结构阅读、符号定义定位、导入导出查看、类/函数成员大纲、局部实现精读前的结构化扫描，优先使用 `ast-grep outline`。
+- **冲突处理**：如果 CodeGraph 与 `ast-grep outline` 结果冲突，以 `ast-grep outline` 的结构化大纲结果为准，再通过定向文件阅读确认。
+```
+
+#### 6.4.2 `mcp-servers.md` 新规则
+
+在 `cadence-init/references/rules/mcp-servers.md` 与 `.claude/rules/mcp-servers.md` 中增加 CodeGraph MCP 章节：
+
+````markdown
+### CodeGraph MCP
+
+**用途**：基于项目代码图进行大范围代码检索、架构理解、调用链分析和影响面分析。
+
+**触发场景**：
+- 需要理解某个功能跨文件如何工作
+- 需要分析调用链、依赖关系或影响面
+- 需要进行大范围代码检索
+- 需要回答“某功能从入口到落点如何流转”
+
+**使用规则**：
+1. 项目必须先执行 `codegraph init`，存在 `.codegraph/` 后 CodeGraph MCP 才提供工具。
+2. 大范围检索优先使用 CodeGraph。
+3. 精确结构阅读优先使用 `ast-grep outline`。
+4. `ast-grep` 与 CodeGraph 结果冲突时，以 `ast-grep` 为准。
+
+**手动服务命令**：
+```bash
+codegraph serve --mcp
+```
+````
+
+### 6.5 `CLAUDE.md` 与 `AGENTS.md` 同步
+
+在现有“代码阅读规则”摘要中增加 CodeGraph 表述，避免新增独立规则编号造成编号 churn。
+
+建议改为：
+
+```markdown
+### 8. 代码阅读规则
+- **大范围检索使用 CodeGraph，精确结构阅读优先使用 `ast-grep outline`** → 详见 `.claude/rules/code-reading.md`
+```
+
+`AGENTS.md` 同步使用同样表述。
+
+## 7. 增量运行策略
+
+### 7.1 `/pre-check`
+
+重复运行时：
+
+| 场景 | 行为 |
+|------|------|
+| CodeGraph 已安装 | 报告版本并跳过安装 |
+| CodeGraph 未安装 | 执行 `npm i -g @colbymchenry/codegraph` |
+| 安装后验证失败 | 报告失败并给出手动安装命令 |
+
+### 7.2 `/rule-config`
+
+重复运行时：
+
+| 场景 | 行为 |
+|------|------|
+| `.codegraph/` 已存在 | 报告已初始化，不重复 `codegraph init` |
+| `.codegraph/` 不存在 | 询问是否初始化 |
+| CodeGraph 规则文件已存在 | 检查摘要是否缺失，不自动覆盖规则全文 |
+| `CLAUDE.md` / `AGENTS.md` 已有 CodeGraph 标记片段 | 不重复写入 |
+| `.gitignore` 已包含 `.codegraph/` | 跳过 |
+
+## 8. 实施步骤
+
+1. 修改 `/pre-check` 文档：
+   - 更新 `cadence-init/skills/pre-check/SKILL.md`
+   - 更新 `cadence-init/commands/pre-check.md`
+
+2. 修改 `/rule-config` 文档：
+   - 增加 CodeGraph 项目初始化步骤
+   - 更新检查清单编号
+   - 更新增量运行说明
+   - 更新 `.gitignore` 处理规则
+
+3. 修改 MCP 配置文档：
+   - 在 `cadence-init/commands/mcp-configuration.md` 中增加 CodeGraph 手动配置兜底
+   - 确认 Codex 同步配置包含 `[mcp_servers.codegraph]`
+
+4. 修改规则模板与当前项目规则：
+   - 更新 `cadence-init/references/rules/code-reading.md`
+   - 更新 `cadence-init/references/rules/mcp-servers.md`
+   - 更新 `.claude/rules/code-reading.md`
+   - 更新 `.claude/rules/mcp-servers.md`
+
+5. 同步入口文件：
+   - 更新 `CLAUDE.md` 的代码阅读规则摘要
+   - 更新 `AGENTS.md` 的代码阅读规则摘要
+
+6. 验证：
+   - 检查 Markdown 格式
+   - 检查规则编号一致性
+   - 检查 `cadence-init/` 中 Serena 仍无残留
+   - 检查 CodeGraph 关键命令均出现
+
+## 9. 验证清单
+
+实施后执行：
+
+```bash
+rg -n "codegraph|CodeGraph|\\.codegraph|@colbymchenry/codegraph" cadence-init .claude CLAUDE.md AGENTS.md
+rg -n "serena|Serena|\\.serena|mcp__serena" cadence-init
+rg -n "大范围检索|精确检索|ast-grep outline" cadence-init/references/rules .claude/rules CLAUDE.md AGENTS.md
+```
+
+人工检查：
+
+1. `/pre-check` 基础检查数量是否统一为五项。
+2. `/rule-config` 步骤编号是否连续。
+3. CodeGraph 初始化是否明确限定 `--target=claude,codex --location=local`。
+4. `.codegraph/` 是否被忽略，`codegraph.json` 是否未被忽略。
+5. `ast-grep` 与 CodeGraph 冲突处理是否明确。
+
+## 10. 风险与处理
+
+| 风险 | 影响 | 处理 |
+|------|------|------|
+| `codegraph install` 修改 `CLAUDE.md` / `AGENTS.md` 的 marker 片段 | 可能与 Cadence 摘要规则重复 | 文档中要求检测已有片段，不重复写入 |
+| CodeGraph 建图时间较长 | 大型项目初始化耗时 | 提示用户可先配置 `codegraph.json` 排除大型已提交目录 |
+| `.codegraph/` 被误提交 | 本地 SQLite 索引进入版本库 | `/rule-config` 初始化后写入 `.gitignore` |
+| Codex 配置重复 | `.codex/config.toml` 中出现重复 server | 写入前检查 `[mcp_servers.codegraph]` |
+| CodeGraph 与 `ast-grep` 结论不一致 | Agent 判断不稳定 | 明确以 `ast-grep outline` 为准，再定向精读确认 |
+
+## 11. 待确认事项
+
+1. 本次实施是否严格限定在 `cadence-init`、规则模板、当前项目入口规则，不处理 `cadence-workflow/` 与 `readmes/skills/` 的 Serena 文案。
+2. 是否允许 `/rule-config` 直接执行 `codegraph init` 完成建图，还是只写入命令说明并由用户手动执行。
+3. 是否需要在 `mcp-configuration.md` 的基础 MCP 配置中默认包含 CodeGraph，还是仅作为 `/rule-config` 项目初始化后的兜底说明。
+
+## 12. 推荐结论
+
+推荐按以下策略实施：
+
+1. `/pre-check` 负责安装 CodeGraph CLI。
+2. `/rule-config` 负责项目级 `codegraph install` 与 `codegraph init`。
+3. `/mcp-configuration` 只补充手动兜底配置，不把 CodeGraph 纳入原有基础 MCP 模板的必选项。
+4. 代码阅读规则统一表达为“大范围检索用 CodeGraph，精确结构阅读用 `ast-grep outline`，冲突时以 `ast-grep` 为准”。
+5. 本次不处理 `cadence-workflow/` 和 `readmes/skills/` 中的 Serena 依赖，避免扩大为工作流持久化机制重构。

--- a/cadence/plans/2026-06-29_计划文档_实施_CodeGraph集成与增量初始化_v1.0.md
+++ b/cadence/plans/2026-06-29_计划文档_实施_CodeGraph集成与增量初始化_v1.0.md
@@ -1,0 +1,68 @@
+# 计划文档：实施 CodeGraph 集成与增量初始化
+
+**日期**：2026-06-29
+**版本**：v1.0
+**目标分支**：feat-b-0629
+**关联方案**：`cadence/designs/2026-06-29_方案设计_CodeGraph集成与Serena检查_v1.0.md`
+
+## 目标
+
+在 Cadence 初始化链路中实现 CodeGraph 支持，并确保 `/pre-check` 与 `/rule-config` 可以反复增量执行。
+
+## 实施范围
+
+| 文件 | 目标 |
+|------|------|
+| `cadence-init/skills/pre-check/SKILL.md` | 增加 CodeGraph 检查、安装、验证和增量说明 |
+| `cadence-init/commands/pre-check.md` | 增加 CodeGraph 安装章节和强制规则 |
+| `cadence-init/commands/rule-config.md` | 增加 CodeGraph 项目初始化与增量补齐逻辑 |
+| `cadence-init/commands/mcp-configuration.md` | 增加 CodeGraph MCP 手动兜底配置 |
+| `cadence-init/references/rules/code-reading.md` | 增加 CodeGraph 与 `ast-grep outline` 分工 |
+| `cadence-init/references/rules/mcp-servers.md` | 增加 CodeGraph MCP 使用规则 |
+| `.claude/rules/code-reading.md` | 同步当前项目代码阅读规则 |
+| `.claude/rules/mcp-servers.md` | 同步当前项目 MCP 规则 |
+| `CLAUDE.md` | 更新代码阅读规则摘要 |
+| `AGENTS.md` | 更新代码阅读规则摘要 |
+
+## 执行步骤
+
+1. 更新 `/pre-check`：
+   - 基础检查从四项改为五项。
+   - 新增 `codegraph version` 检查。
+   - 新增 `npm i -g @colbymchenry/codegraph` 安装命令。
+   - 明确重复运行时只补装缺失工具。
+
+2. 更新 `/rule-config`：
+   - 在代码阅读规则后新增 CodeGraph 项目初始化。
+   - 命令固定为 `codegraph install --target=claude,codex --location=local --yes` 与 `codegraph init`。
+   - 明确 `.codegraph/` 加入 `.gitignore`，`codegraph.json` 不忽略。
+   - 明确重复运行时只补缺失规则、摘要、MCP 配置和初始化状态。
+
+3. 更新 MCP 配置说明：
+   - 增加 Claude Code `.mcp.json` 兜底片段。
+   - 增加 Codex `.codex/config.toml` 兜底片段。
+   - 写明 CodeGraph 是 stdio MCP，可同步到 Codex。
+
+4. 更新规则文件：
+   - `code-reading.md` 明确大范围检索用 CodeGraph，精确结构阅读用 `ast-grep outline`。
+   - `mcp-servers.md` 增加 CodeGraph MCP 章节。
+
+5. 更新入口摘要：
+   - `CLAUDE.md` 与 `AGENTS.md` 的代码阅读规则摘要同步改为 CodeGraph + `ast-grep outline` 分工。
+
+## 验证命令
+
+```bash
+rg -n "codegraph|CodeGraph|\\.codegraph|@colbymchenry/codegraph" cadence-init .claude CLAUDE.md AGENTS.md
+rg -n "serena|Serena|\\.serena|mcp__serena" cadence-init
+rg -n "大范围检索|精确结构阅读|ast-grep outline|反复增量|只补" cadence-init .claude CLAUDE.md AGENTS.md
+git diff --check
+```
+
+## 验收标准
+
+1. `/pre-check` 文档明确包含 CodeGraph 安装与增量补装。
+2. `/rule-config` 文档明确包含项目级 CodeGraph 初始化与增量补齐。
+3. Claude Code 与 Codex 的 CodeGraph MCP 配置均有兜底说明。
+4. 代码阅读规则明确 CodeGraph 与 `ast-grep outline` 的职责边界。
+5. `cadence-init/` 中不重新引入 Serena。


### PR DESCRIPTION
## Summary
- add CodeGraph checks and installation guidance to /pre-check
- add project-local CodeGraph initialization and incremental handling to /rule-config
- document CodeGraph MCP fallback configuration for Claude Code and Codex
- sync CodeGraph + ast-grep code-reading rules in templates and current project rules

## Verification
- rg "serena|Serena|\.serena|mcp__serena" cadence-init returned no matches
- rg checks confirmed CodeGraph install/init/MCP/incremental wording is present
- git diff --check passed