### PR TITLE
docs(rule-config): 补 no-interrupt 模式冲突实际动作汇报指引

### DIFF
--- a/cadence-init/skills/rule-config/SKILL.md
+++ b/cadence-init/skills/rule-config/SKILL.md
@@ -74,6 +74,8 @@ python3 "<RULE_CONFIG_PY>" apply --project-root "<PROJECT_ROOT>" --report "<REPO
 
 单次 apply：直接执行 `apply --no-interrupt` 一次完成（可选先跑 dry-run 摸底）。脚本不读取也不要求决策文件，全部冲突按 `references/merge-semantics.md` 的权威规则内部决策并记入报告。此模式禁止 Agent 调用 `AskUserQuestion`、`request_user_input` 或等价提问工具，禁止等待用户输入。
 
+**汇报冲突实际动作（强制）**：no-interrupt 模式下汇报某冲突的处理结果时，Agent MUST 依据该冲突条目的 `no_interrupt_action` 字段（如 `authoritative-overwrite`）或对应 `steps[].actions[]` 条目的 `action`/`branch`（如 `overwritten`/`authoritative-overwrite`）描述**实际执行动作**。`default_keep` 与 `recommendation` 是**普通模式无响应时的安全兜底语义**（保留原文件并报告 status=0），no-interrupt 模式不读取也不按其执行，Agent MUST NOT 用其描述 no-interrupt 实际动作（例如不得把框架规则文件 drift 的 `authoritative-overwrite` 说成"已保留现有文件"）。
+
 ## 有界扫描说明
 
 项目类型检测使用一次有界首命中扫描。以下命令**仅用于项目类型判定**，其剪枝目录清单与脚本 `PRUNE_DIRS` 常量逐项一致，不得增删：
@@ -97,10 +99,12 @@ find . \
 ```bash
 # 总体结果与项目类型
 python3 -c "import json;d=json.load(open('<REPORT>'));print(d['overall'], d['project_type'])"
-# 冲突清单（普通模式提问与决策文件依据）
+# 冲突清单（普通模式提问与决策文件依据；no-interrupt 模式另含 no_interrupt_action 字段标注实际动作）
 python3 -c "import json;d=json.load(open('<REPORT>'));print(json.dumps(d.get('conflicts',[]),ensure_ascii=False,indent=2))"
 # 各步骤状态
 python3 -c "import json;d=json.load(open('<REPORT>'));print([(s['name'],s['status']) for s in d['steps']])"
+# 各资产实际动作明细（no-interrupt 模式汇报冲突结果的权威依据）
+python3 -c "import json;d=json.load(open('<REPORT>'));print([(a.get('path'),a.get('action'),a.get('branch')) for s in d['steps'] for a in s.get('actions',[])])"
 # 失败详情与恢复建议
 python3 -c "import json;d=json.load(open('<REPORT>'));print(d.get('failure'))"
 ```


### PR DESCRIPTION
## 背景

naruto 项目实测 rule-config no-interrupt 模式时，Agent 汇报文案出现误导：对框架规则文件 drift（mcp-servers.md、code-reading.md）输出"已保留现有文件"，但脚本实际执行的是 `authoritative-overwrite` 权威覆盖（归档旧文件 + 写模板，Serena 旧污染已清除并归档到 cadence/legacy/）。

## 根因

SKILL.md 缺少 no-interrupt 模式下 Agent 汇报冲突实际动作的指引。Agent 误用了 `default_keep`/`recommendation`（普通模式无响应兜底语义，"保留原文件"）来描述 no-interrupt 实际动作，而没依据 `no_interrupt_action` 字段或 `steps[].actions[].branch`。

脚本行为本身完全正确（naruto 实测验证：归档、权威覆盖、Serena 清除、幂等均符合新设计），本次只修 Agent 汇报指引文档，不改脚本。

## 修改

只改 `cadence-init/skills/rule-config/SKILL.md`（5 行）：

1. **no-interrupt 模式段落**新增"汇报冲突实际动作（强制）"：Agent MUST 依据 `no_interrupt_action` 字段或 `steps[].actions[].branch` 描述实际动作；`default_keep`/`recommendation` 是普通模式兜底，MUST NOT 用于描述 no-interrupt 实际动作，并点名反例。
2. **报告解读段落**：冲突清单示例注释区分两模式；新增提取 `steps[].actions[]` 实际动作明细的示例（标注为 no-interrupt 汇报权威依据）。

## 验证

- `openspec validate --specs`：9 passed
- 代码围栏配对正确
- `git diff --check` 无空白错误