### PR TITLE
feat: 支持 Kimi Code 第四客户端 + codex 判定适配最新 OpenSpec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 # macOS
 .DS_Store
 
+# Python 缓存
+__pycache__/
+
 # pi-subagents 运行时产物（审查/任务临时工件）
 .pi-subagents/

--- a/README.md
+++ b/README.md
@@ -214,10 +214,10 @@ git pull
 
 | Skill | 默认行为 | 需要显式启用的内容 |
 |------|----------|--------------------|
-| `/pre-check` | 一键检查并补齐六个基础工具 `npx`、`uvx`、`ast-grep`、`codegraph`、OpenSpec、pi-mcp-adapter（pi 存在时）：已装的工具秒级跳过，缺什么装什么，装完自动复验；支持**大陆镜像加速**与**一键升级已装工具**（见下方“大陆镜像与工具升级”）；OpenSpec 检查范围为 CLI 与 `claude,codex,pi` 三客户端指令产物，按缺失客户端精确补齐（缺哪个 init 哪个）；`openspec/config.yaml` 由 `/rule-config` 创建与合并，缺失时仅提示不影响判定；Superpowers 软链同步到 `~/.agents/skills`、`~/.codex/skills/skills`、`~/.claude/skills`、`~/.pi/agent/skills` 四层；支持 Superpowers 离线目录 `~/.agents/superpowers`；默认只写 API Key 占位提醒，不收集真实密钥 | Playwright 安装 |
+| `/pre-check` | 一键检查并补齐六个基础工具 `npx`、`uvx`、`ast-grep`、`codegraph`、OpenSpec、pi-mcp-adapter（pi 存在时）：已装的工具秒级跳过，缺什么装什么，装完自动复验；支持**大陆镜像加速**与**一键升级已装工具**（见下方“大陆镜像与工具升级”）；OpenSpec 检查范围为 CLI 与 `claude,codex,pi,kimi` 四客户端指令产物，按缺失客户端精确补齐（缺哪个 init 哪个）；`openspec/config.yaml` 由 `/rule-config` 创建与合并，缺失时仅提示不影响判定；Superpowers 软链同步到 `~/.agents/skills`、`~/.codex/skills/skills`、`~/.claude/skills`、`~/.pi/agent/skills` 四层；支持 Superpowers 离线目录 `~/.agents/superpowers`；默认只写 API Key 占位提醒，不收集真实密钥 | Playwright 安装 |
 | `/project-analysis` | 分析项目结构、技术栈和依赖，生成项目初始化分析摘要文档 | — |
 | `/rule-config` | 自动检测项目类型和技术栈；创建 `.claude/rules/`、`CLAUDE.md`、`AGENTS.md`、`cadence/` 目录；创建或保守合并 `openspec/config.yaml`（含 Cadence 协作上下文）；生成并升级 OpenSpec × Superpowers L0/L1/L2 协作规则；Coding 项目默认启用代码阅读规则和 CodeGraph 初始化；普通规则已有文件不覆盖 | Playwright 规则；将 `cadence/` 加入 `.gitignore` |
-| `/mcp-configuration` | 默认写入基础 MCP、CodeGraph MCP、智普 MCP 占位配置、MiniMax MCP 占位配置；默认同步 stdio MCP 到 `.codex/config.toml`；pi 无原生 MCP，经 pi-mcp-adapter 直接复用 `.mcp.json`（含 HTTP 类型 server），不维护第二份配置；真实 API Key 由用户后续自行替换 | 禁用默认 MCP 或处理同名冲突 |
+| `/mcp-configuration` | 默认写入基础 MCP、CodeGraph MCP、智普 MCP 占位配置、MiniMax MCP 占位配置；默认同步 stdio MCP 到 `.codex/config.toml`；pi 无原生 MCP，经 pi-mcp-adapter 直接复用 `.mcp.json`（含 HTTP 类型 server），不维护第二份配置；Kimi Code 原生复用根目录 `.mcp.json`（含 HTTP server），不维护第二份配置；真实 API Key 由用户后续自行替换 | 禁用默认 MCP 或处理同名冲突 |
 | `/project-rules-examples` | 创建 `cadence/project-rules/` 个性化规则模板，补齐 CLAUDE.md / AGENTS.md 引用；已有模板不覆盖 | 覆盖已有模板或深度定制项目事实 |
 
 ### KnowledgeBase Skills
@@ -317,7 +317,7 @@ $knowledge-base-context
 
 | Skill | no-interrupt 模式行为 |
 |------|------------------------|
-| `/pre-check` | 除 Playwright 外，由脚本强制完成 npx、uvx、ast-grep、codegraph、OpenSpec（CLI 与三客户端指令产物；`openspec/config.yaml` 缺失不算失败，由 `/rule-config` 创建）、pi-mcp-adapter 的安装和验证；任一基础工具失败立即终止；Superpowers 同步四层软链（含 `~/.pi/agent/skills`）且固定离线目录无效时直接报错；同名冲突先备份再处理；PATH 中存在 pi 可执行文件但 `pi-mcp-adapter` 安装失败时立即终止，pi 不存在时跳过不算失败 |
+| `/pre-check` | 除 Playwright 外，由脚本强制完成 npx、uvx、ast-grep、codegraph、OpenSpec（CLI 与四客户端指令产物；`openspec/config.yaml` 缺失不算失败，由 `/rule-config` 创建）、pi-mcp-adapter 的安装和验证；任一基础工具失败立即终止；Superpowers 同步四层软链（含 `~/.pi/agent/skills`）且固定离线目录无效时直接报错；同名冲突先备份再处理；PATH 中存在 pi 可执行文件但 `pi-mcp-adapter` 安装失败时立即终止，pi 不存在时跳过不算失败 |
 | `/rule-config` | 冲突时以 `rule-config` 模板和强制规则为准，项目已有内容作为补充合并；只报告历史文档目录，不执行迁移 |
 | `/mcp-configuration` | 冲突时以标准 MCP 结构和必需参数为准，保留项目额外 Server、扩展字段和已有非占位密钥；解析或验证失败时恢复备份并终止 |
 | `/project-rules-examples` | 冲突时以标准模板骨架和强制约束为准，保留项目事实、真实占位值和额外章节；无法结构化合并时备份并保留原文 |
@@ -335,7 +335,7 @@ $knowledge-base-context
 /project-rules-examples no-interrupt
 ```
 
-> **职责边界**：`/pre-check` 负责 OpenSpec CLI 与三客户端指令产物；`openspec/config.yaml` 由 `/rule-config` 步骤 11 创建与合并（含 Cadence 协作上下文）。顺序保持 `/pre-check` 先、`/rule-config` 后；即使顺序颠倒，`/pre-check` 也会按缺失客户端补齐产物且保留已有 config.yaml。
+> **职责边界**：`/pre-check` 负责 OpenSpec CLI 与四客户端指令产物；`openspec/config.yaml` 由 `/rule-config` 步骤 11 创建与合并（含 Cadence 协作上下文）。顺序保持 `/pre-check` 先、`/rule-config` 后；即使顺序颠倒，`/pre-check` 也会按缺失客户端补齐产物且保留已有 config.yaml。
 
 如果需要 Playwright，请明确说明：
 
@@ -365,7 +365,7 @@ your_minimax_api_key
 - ✅ 检查并补齐六个基础工具：`npx`、`uvx`、`ast-grep`、`codegraph`、OpenSpec、pi-mcp-adapter（pi 存在时）；已安装的工具**秒级跳过**，缺什么装什么，装完自动复验
 - ✅ **大陆镜像加速**：国内网络可切换淘宝 npm 镜像、清华 pypi 镜像与国内 Git 镜像（见下方“大陆镜像与工具升级”）
 - ✅ **一键升级**：可把 `ast-grep`、`codegraph`、OpenSpec、`uv` 升级到当前源最新版本（见下方“大陆镜像与工具升级”）
-- ✅ OpenSpec 检查 CLI 与 `claude,codex,pi` 三客户端指令产物，缺失哪个客户端就先 `openspec init --tools <缺失客户端>` 再 `openspec update`；`openspec/config.yaml` 由 `/rule-config` 创建，缺失时仅提示
+- ✅ OpenSpec 检查 CLI 与 `claude,codex,pi,kimi` 四客户端指令产物，缺失哪个客户端就先 `openspec init --tools <缺失客户端>` 再 `openspec update`；`openspec/config.yaml` 由 `/rule-config` 创建，缺失时仅提示
 - ✅ Superpowers 软链同步到 `~/.agents/skills`、`~/.codex/skills/skills`、`~/.claude/skills`、`~/.pi/agent/skills` 四层，支持在线更新与离线目录同步
 - ✅ 检测到 pi 可执行文件时条件检查并安装 `pi-mcp-adapter`（未安装 pi 时跳过）
 - ✅ 默认跳过 Playwright，除非显式启用
@@ -516,7 +516,7 @@ Cadence 当前以 Skill 形式提供能力，不再提供独立的 Command。其
 
 - 自动检测项目类型和技术栈
 - 跨平台兼容（macOS/Linux/Windows）
-- 同时支持 Claude Code、Codex 与 pi 三类客户端的环境初始化（OpenSpec 产物、Superpowers 软链、MCP 接入）
+- 同时支持 Claude Code、Codex、pi 与 Kimi Code 四类客户端的环境初始化（OpenSpec 产物、Superpowers 软链、MCP 接入）
 - 用户确认机制确保准确性
 
 ## 哲学

--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ OpenSpec 管契约，Superpowers 管行为。规则模板同时定义 Claude/Kim
 - ✅ 默认写入智普/MiniMax API Key 占位配置
 - ✅ 默认同步 stdio MCP 到 `.codex/config.toml`（Codex 不支持 HTTP 类型 MCP）
 - ✅ pi 经 pi-mcp-adapter 直接复用 `.mcp.json`（含 HTTP 类型 server），不维护第二份配置
+- ✅ Kimi Code 原生复用根目录 `.mcp.json`（含 HTTP server），不维护第二份配置
 - ✅ 默认将 `.worktrees/`、`.mcp.json`、`.codex/` 加入 `.gitignore`
 
 ### 步骤 5（推荐）：项目个性化规则

--- a/cadence-init/skills/mcp-configuration/SKILL.md
+++ b/cadence-init/skills/mcp-configuration/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 ## 概述
 
-配置 MCP 服务器：创建 `.mcp.json` 配置文件、同步 Codex `.codex/config.toml`，并添加 MCP 使用规则到 CLAUDE.md。pi 无原生 MCP，由 `/pre-check` 全局安装的 pi-mcp-adapter 扩展直接读取 `.mcp.json`（含 HTTP 类型 server），无需同步第二份配置。默认不需要人工交互即可完成基础 MCP 初始化。
+配置 MCP 服务器：创建 `.mcp.json` 配置文件、同步 Codex `.codex/config.toml`，并添加 MCP 使用规则到 CLAUDE.md。pi 无原生 MCP，由 `/pre-check` 全局安装的 pi-mcp-adapter 扩展直接读取 `.mcp.json`（含 HTTP 类型 server），无需同步第二份配置。Kimi Code 原生读取项目根 `.mcp.json`（三层加载：`~/.kimi-code/mcp.json` → `<项目根>/.mcp.json` → `<cwd>/.kimi-code/mcp.json`，后者覆盖前者），本 Skill 维护的 `.mcp.json` 即 Kimi 的 MCP 配置来源，无需同步第二份配置。默认不需要人工交互即可完成基础 MCP 初始化。
 
 ## 参数模式
 
@@ -108,7 +108,8 @@ Server 名称使用精确名称匹配，不进行大小写归一化。`.mcp.json
 4. **配置 MiniMax MCP** — 默认写入 MiniMax Token Plan MCP 占位配置
 5. **同步 MCP 配置到 Codex** — 默认同步为 Codex 的 `.codex/config.toml` 格式，仅同步 stdio MCP
 6. **pi MCP 说明** — 说明 pi 经 pi-mcp-adapter 直接读取 `.mcp.json`（含 HTTP server），不维护第二份配置
-7. **配置 .gitignore** — 添加 `.worktrees/`、`.mcp.json` 和 `.codex/config.toml` 到 .gitignore
+7. **Kimi MCP 说明** — 说明 Kimi Code 原生读取项目根 `.mcp.json`（含 stdio/HTTP/SSE），不维护第二份配置
+8. **配置 .gitignore** — 添加 `.worktrees/`、`.mcp.json` 和 `.codex/config.toml` 到 .gitignore（Kimi 复用 `.mcp.json`，无需新增条目）
 
 **下一步**：将配置结果传递给 @project-rules-examples skill 创建个性化规则示例
 
@@ -559,16 +560,18 @@ MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-pla
 - 写入顺序：基础配置 → CodeGraph 配置（仅 Coding 项目） → 智普配置（默认占位）→ MiniMax 配置（默认占位）
 - **Codex 不支持 HTTP 类型 MCP** — 同步时必须排除所有 `"type": "http"` 的 MCP servers，仅同步 stdio 类型（有 `command` 字段）的服务
 
-**Claude Code、Codex 与 pi 格式差异**：
+**Claude Code、Codex、pi 与 Kimi Code 格式差异**：
 
-| 特征 | Claude Code (`.mcp.json`) | Codex (`.codex/config.toml`) | pi（pi-mcp-adapter） |
-|------|--------------------------|------------------------------|----------------------|
-| 格式 | JSON | TOML | 复用 `.mcp.json`（JSON），无第二份配置 |
-| 服务器定义 | `"mcpServers": { "name": {...} }` | `[mcp_servers.name]` | 同 `.mcp.json` |
-| 传输类型 | `"type": "stdio"` / `"type": "http"` | 仅 stdio（有 `command`），**HTTP 类型不支持** | stdio 与 HTTP 均支持 |
-| 环境变量 | `"env": { "KEY": "value" }` | `env = { "KEY" = "value" }` | 同 `.mcp.json` |
-| HTTP 头 | `"headers": { "Authorization": "..." }` | `http_headers = { "Authorization" = "..." }` | 同 `.mcp.json` |
-| type 字段 | 必须显式声明 | 不需要（自动推断） | 同 `.mcp.json` |
+| 特征 | Claude Code (`.mcp.json`) | Codex (`.codex/config.toml`) | pi（pi-mcp-adapter） | Kimi Code（原生） |
+|------|--------------------------|------------------------------|----------------------|-------------------|
+| 格式 | JSON | TOML | 复用 `.mcp.json`（JSON），无第二份配置 | 复用根目录 `.mcp.json`（JSON），无第二份配置 |
+| 服务器定义 | `"mcpServers": { "name": {...} }` | `[mcp_servers.name]` | 同 `.mcp.json` | 同 `.mcp.json` |
+| 传输类型 | `"type": "stdio"` / `"type": "http"` | 仅 stdio（有 `command`），**HTTP 类型不支持** | stdio 与 HTTP 均支持 | stdio / HTTP / SSE 均支持 |
+| 环境变量 | `"env": { "KEY": "value" }` | `env = { "KEY" = "value" }` | 同 `.mcp.json` | 同 `.mcp.json` |
+| HTTP 头 | `"headers": { "Authorization": "..." }` | `http_headers = { "Authorization" = "..." }` | 同 `.mcp.json` | 同 `.mcp.json` |
+| type 字段 | 必须显式声明 | 不需要（自动推断） | 同 `.mcp.json` | 不需要（按 `command`/`url` 自动推断） |
+
+> 说明：Kimi 的 schema 为非严格解析，`.mcp.json` 中 pi 扩展的 `directTools` 等未知字段会被静默忽略，无需为 Kimi 剥离。
 
 **信任提醒**：
 - 提醒用户：首次在 Codex 中打开项目时需确认信任项目，否则 `.codex/config.toml` 不会被加载
@@ -637,6 +640,17 @@ env = { "MINIMAX_API_KEY" = "your_minimax_api_key", "MINIMAX_API_HOST" = "https:
 - `.gitignore` 无需新增条目：pi 复用的 `.mcp.json` 已在忽略清单内。
 
 **pi 侧验证方式**：pi 会话中输入 `/mcp`（由 adapter 提供）查看 server 列表与连接状态。
+
+### 7.5 Kimi Code MCP 说明
+
+> **无需同步步骤** — Kimi Code 不维护第二份 MCP 配置文件。
+
+- Kimi Code 原生支持 MCP（stdio / HTTP / SSE 三种传输），直接读取项目根目录 `.mcp.json`（源码三层加载：`~/.kimi-code/mcp.json` → `<项目根>/.mcp.json` → `<cwd>/.kimi-code/mcp.json`，后者覆盖前者）。
+- 本 Skill 维护的 `.mcp.json` 即 Kimi 的 MCP 配置来源：智普的 `web-search-prime`、`web-reader`、`zread`（HTTP）与 `zai-mcp-server`、MiniMax（stdio）在 Kimi 下均可用，无需任何同步。
+- `.mcp.json` 中的 `directTools` 等 pi 扩展字段对 Kimi 无害（非严格 schema 静默忽略）。
+- `.gitignore` 无需新增条目：Kimi 复用的 `.mcp.json` 已在忽略清单内。
+
+**Kimi 侧验证方式**：Kimi Code 会话中输入 `/mcp` 查看 server 连接状态，输入 `/mcp-config` 交互式新增/编辑/删除 server。
 
 ### 8. 配置 .gitignore
 

--- a/cadence-init/skills/pre-check/SKILL.md
+++ b/cadence-init/skills/pre-check/SKILL.md
@@ -344,6 +344,8 @@ cd "<PROJECT_ROOT>" && test "$(find .kimi-code/skills -mindepth 1 -maxdepth 1 -t
 | Claude Code 目标目录 | `~/.claude/skills` |
 | pi 目标目录 | `~/.pi/agent/skills` |
 
+> 说明：Kimi Code 扫描用户级通用目录 `~/.agents/skills`（superpowers 软链第 2 层即此目录），经该层直接获得 Superpowers skills，无需新增 `~/.kimi-code/skills` 软链目标；`~/.kimi-code/skills` 是 Kimi 专属用户 skills 目录，不放通用 superpowers。
+
 **在线安装来源**：
 
 > **执行位置与产物**：clone 产物落在 `$HOME/.agents/superpowers`（绝对路径，不受执行目录影响）。报告路径用步骤 0 确定的 `<REPORT>`（`/tmp` 下 mktemp 生成的独占绝对路径字面值）；若该文件不存在，先回步骤 0 生成报告再读本节。

--- a/cadence-init/skills/pre-check/SKILL.md
+++ b/cadence-init/skills/pre-check/SKILL.md
@@ -10,7 +10,7 @@ disable-model-invocation: true
 
 自动化环境检查和配置工具，确保项目所需的工具、依赖项、OpenSpec 指令文件和 Superpowers Skills 正确安装。默认使用无人工交互策略完成初始化。
 
-**副作用说明**：本 Skill 不修改用户全局配置文件（`~/.npmrc`、uv 配置、`git config --global`），但并非完全无写入。预期行为包括：`run` 会全局安装缺失的基础工具（ast-grep/codegraph/openspec/uv 等）；`--upgrade` 会升级这些工具到当前源最新版；Superpowers 步骤会 clone 并更新本地仓库 origin（用于切换国内镜像）。openspec 产物与 `.claude/.codex/.pi` 写入待初始化项目根目录。
+**副作用说明**：本 Skill 不修改用户全局配置文件（`~/.npmrc`、uv 配置、`git config --global`），但并非完全无写入。预期行为包括：`run` 会全局安装缺失的基础工具（ast-grep/codegraph/openspec/uv 等）；`--upgrade` 会升级这些工具到当前源最新版；Superpowers 步骤会 clone 并更新本地仓库 origin（用于切换国内镜像）。openspec 产物与 `.claude/.agents/.pi/.kimi-code` 写入待初始化项目根目录。
 
 ## 参数模式
 
@@ -180,7 +180,7 @@ digraph check_flow {
 
 **第一步——确定两个字面路径（模型先执行一次，记住字面值，后续每条命令直接写出）**：
 
-1. **项目根 `<PROJECT_ROOT>`**：待初始化项目的绝对路径。先执行 `pwd`（或 `pwd -P`）得到它，例如 `/home/user/my-project`。所有 openspec 产物与 `.claude/.codex/.pi` 都落在该目录（报告文件在下一步单独放在 `/tmp`，不在项目根）。
+1. **项目根 `<PROJECT_ROOT>`**：待初始化项目的绝对路径。先执行 `pwd`（或 `pwd -P`）得到它，例如 `/home/user/my-project`。所有 openspec 产物与 `.claude/.agents/.pi/.kimi-code` 都落在该目录（报告文件在下一步单独放在 `/tmp`，不在项目根）。
 2. **脚本 `<PRE_CHECK_SH>`**：脚本是本 pre-check skill 的关联脚本，位于 pre-check skill 目录下的 `scripts/pre-check.sh`。模型根据自身安装环境定位 skill 目录并拼出完整绝对路径（例如 `<skill 安装根>/cadence-init/skills/pre-check/scripts/pre-check.sh`）。脚本只读，**不要** `cd` 进 skill 目录，也**不要**把脚本单独复制到别处执行——它依赖同目录下的 `mirrors/`（镜像配置），必须连同 skill 目录一起定位。
 
 **第二步——确定独占报告路径 `<REPORT>`**：报告是临时中间产物，用 `mktemp` 在 `/tmp` 生成**原子唯一**路径（避免同秒并发/重复运行冲突）。执行一次 `mktemp -t precheck-report.XXXXXX.json`，得到形如 `/tmp/precheck-report.aB3dEf.json` 的唯一路径，**记住这个字面值**记为 `<REPORT>`，后续每条命令直接写出它（**加引号**）。不要用 `date +%s`（同秒并发会重名），也不要用 `pwd` 推导（独立 shell 的 cwd 会变）。
@@ -277,7 +277,7 @@ ls ~/.claude/skills/playwright-cli
 
 **初始化与更新命令**：
 
-> **执行位置**：`openspec init`/`openspec update` 作用于当前工作目录，产物（`.claude/.codex/.pi/.kimi-code`）写入该目录。为在独立 shell 下确保落到项目根，每条命令用 `cd "<PROJECT_ROOT>" && ...` 自包含（`<PROJECT_ROOT>` 为步骤 0 确定的项目根绝对路径字面值）。
+> **执行位置**：`openspec init`/`openspec update` 作用于当前工作目录，产物（`.claude/.agents/.pi/.kimi-code`）写入该目录。为在独立 shell 下确保落到项目根，每条命令用 `cd "<PROJECT_ROOT>" && ...` 自包含（`<PROJECT_ROOT>` 为步骤 0 确定的项目根绝对路径字面值）。
 
 ```bash
 # 四客户端产物均缺失（新项目）

--- a/cadence-init/skills/pre-check/SKILL.md
+++ b/cadence-init/skills/pre-check/SKILL.md
@@ -277,7 +277,7 @@ ls ~/.claude/skills/playwright-cli
 
 **初始化与更新命令**：
 
-> **执行位置**：`openspec init`/`openspec update` 作用于当前工作目录，产物（`.claude/.codex/.pi`）写入该目录。为在独立 shell 下确保落到项目根，每条命令用 `cd "<PROJECT_ROOT>" && ...` 自包含（`<PROJECT_ROOT>` 为步骤 0 确定的项目根绝对路径字面值）。
+> **执行位置**：`openspec init`/`openspec update` 作用于当前工作目录，产物（`.claude/.codex/.pi/.kimi-code`）写入该目录。为在独立 shell 下确保落到项目根，每条命令用 `cd "<PROJECT_ROOT>" && ...` 自包含（`<PROJECT_ROOT>` 为步骤 0 确定的项目根绝对路径字面值）。
 
 ```bash
 # 四客户端产物均缺失（新项目）
@@ -309,7 +309,7 @@ cd "<PROJECT_ROOT>" && openspec update
 - 已就绪客户端不得重新 init，不覆盖用户改动。
 - `openspec init` 检测到 `openspec/config.yaml` 已存在时原样保留（CLI 行为），不覆盖 rule-config 写入的内容。
 - `openspec update` 只刷新已初始化的工具产物，不能为未初始化的客户端新增产物；缺失客户端必须由 `openspec init` 补齐。
-- OpenSpec 生成的 Claude Code、Codex 和 pi 目录结构不同，不能混用：
+- OpenSpec 生成的 Claude Code、Codex、pi 与 Kimi Code 目录结构不同，不能混用：
   - Claude Code：`.claude/commands/opsx/`、`.claude/skills/openspec-*`
   - Codex：`.codex/skills/openspec-*`
   - pi：`.pi/prompts/opsx-*`、`.pi/skills/openspec-*`

--- a/cadence-init/skills/pre-check/SKILL.md
+++ b/cadence-init/skills/pre-check/SKILL.md
@@ -300,7 +300,7 @@ cd "<PROJECT_ROOT>" && openspec update
 | 客户端 | 产物就绪判定 |
 |--------|--------------|
 | claude | `.claude/commands/opsx/` 存在，或 `.claude/skills/` 下存在 `openspec-*` 目录 |
-| codex | `.codex/skills/` 下存在 `openspec-*` 目录 |
+| codex | `.agents/skills/` 下存在 `openspec-*` 目录（最新 OpenSpec skills-only，codex 产物落项目根 `.agents/skills/`） |
 | pi | `.pi/skills/` 下恰有 5 个 `openspec-*` 目录，且 `.pi/prompts/` 下恰有 5 个 `opsx-*.md` 文件 |
 | kimi | `.kimi-code/skills/` 下存在 5 个 `openspec-*` 目录 |
 
@@ -311,7 +311,7 @@ cd "<PROJECT_ROOT>" && openspec update
 - `openspec update` 只刷新已初始化的工具产物，不能为未初始化的客户端新增产物；缺失客户端必须由 `openspec init` 补齐。
 - OpenSpec 生成的 Claude Code、Codex、pi 与 Kimi Code 目录结构不同，不能混用：
   - Claude Code：`.claude/commands/opsx/`、`.claude/skills/openspec-*`
-  - Codex：`.codex/skills/openspec-*`
+  - Codex：`.agents/skills/openspec-*`（最新 OpenSpec skills-only，产物落项目根 `.agents/skills/`，不产生 `.codex/`）
   - pi：`.pi/prompts/opsx-*`、`.pi/skills/openspec-*`
   - Kimi Code：`.kimi-code/skills/openspec-*`（无 commands/adapter，仅 5 个 skill）
 - `--tools pi` 需要 OpenSpec CLI >= 1.4.1；步骤 0 脚本始终安装 `@fission-ai/openspec@latest`，版本不足时先回到步骤 0 升级 CLI。
@@ -321,7 +321,7 @@ cd "<PROJECT_ROOT>" && openspec update
 **验证命令**：
 
 ```bash
-cd "<PROJECT_ROOT>" && test -f .codex/skills/openspec-propose/SKILL.md
+cd "<PROJECT_ROOT>" && test -f .agents/skills/openspec-propose/SKILL.md
 cd "<PROJECT_ROOT>" && test -f .claude/commands/opsx/propose.md -o -f .claude/skills/openspec-propose/SKILL.md
 cd "<PROJECT_ROOT>" && test -f .pi/skills/openspec-propose/SKILL.md
 cd "<PROJECT_ROOT>" && test "$(find .pi/skills -mindepth 1 -maxdepth 1 -type d -name 'openspec-*' | wc -l | tr -d ' ')" = 5

--- a/cadence-init/skills/pre-check/SKILL.md
+++ b/cadence-init/skills/pre-check/SKILL.md
@@ -41,7 +41,7 @@ disable-model-invocation: true
 | 项目 | 完成条件 | 失败动作 |
 |------|----------|----------|
 | 六个基础工具 | 脚本 `run --no-interrupt` 退出码为 0 且 JSON `overall=success` | 立即终止 |
-| OpenSpec 三客户端产物 | claude/codex/pi 三客户端目标指令文件验证成功（`openspec/config.yaml` 缺失不算失败，仅提示由 rule-config 创建） | 立即终止 |
+| OpenSpec 四客户端产物 | claude/codex/pi/kimi 四客户端目标指令文件验证成功（`openspec/config.yaml` 缺失不算失败，仅提示由 rule-config 创建） | 立即终止 |
 | Superpowers | 来源目录和四层 Skills 软链验证成功 | 立即终止 |
 | Playwright | 仅用户明确要求时安装和验证 | 未要求时允许跳过 |
 
@@ -124,7 +124,8 @@ digraph when_to_use {
 典型场景：
 - 框架新增 `ast-grep` 后，老项目重新运行 `/pre-check`，只会自动安装 `ast-grep`，不会影响已有的 `npx`、`uvx`、`playwright-cli`。
 - 框架新增 `codegraph` 后，老项目重新运行 `/pre-check`，只会自动安装 `codegraph`，不会影响已有工具。
-- 框架新增 OpenSpec pi 支持后，老项目重新运行 `/pre-check`：缺少 `.pi` 产物时先执行 `openspec init --tools pi`，再执行 `openspec update`；若 pi 产物已存在，则直接执行 `openspec update`。新项目或三客户端产物均缺失时执行 `openspec init --tools claude,codex,pi`。
+- 框架新增 OpenSpec pi 支持后，老项目重新运行 `/pre-check`：缺少 `.pi` 产物时先执行 `openspec init --tools pi`，再执行 `openspec update`；若 pi 产物已存在，则直接执行 `openspec update`。新项目或四客户端产物均缺失时执行 `openspec init --tools claude,codex,pi,kimi`。
+- 框架新增 OpenSpec kimi 支持后，老项目重新运行 `/pre-check`：缺少 `.kimi-code` 产物时先执行 `openspec init --tools kimi`，再执行 `openspec update`；若 kimi 产物已存在，则直接执行 `openspec update`。新项目或四客户端产物均缺失时执行 `openspec init --tools claude,codex,pi,kimi`。
 - 框架新增 Superpowers 后，老项目重新运行 `/pre-check`，只会更新或识别 `~/.agents/superpowers`，补齐 `~/.agents/skills`、`~/.codex/skills/skills`、`~/.claude/skills`、`~/.pi/agent/skills` 的软链。
 - 某个工具安装失败后修复了环境问题，重新运行 `/pre-check` 会再次尝试安装或同步该工具。
 
@@ -140,7 +141,7 @@ digraph check_flow {
     read_report [label="读取 JSON 报告\noverall + steps[]"];
     judge [label="overall 判定", shape=diamond];
     fail_stop [label="失败处理：\nno-interrupt 终止\n普通模式报告不继续"];
-    openspec_clients [label="步骤 5：OpenSpec 三客户端产物补齐"];
+    openspec_clients [label="步骤 5：OpenSpec 四客户端产物补齐"];
     superpowers_sync [label="步骤 6：Superpowers clone/更新 + 四层软链"];
     playwright [label="可选：用户明确要求时安装 Playwright", shape=box];
     apikey [label="API Key 占位提醒"];
@@ -164,7 +165,7 @@ digraph check_flow {
 |------|----------------|----------|----------|
 | **1-6. 基础工具** | `bash "<PRE_CHECK_SH>" run [--mirror cn]` | JSON `overall=success` 且六工具 status 就绪 | 脚本统一安装/复验；失败按模式处理 |
 | （含 npx/uvx/ast-grep/codegraph/openspec/pi-mcp-adapter） | `--upgrade` 升级 npm 系 + uv | `steps[].status` ∈ ready/installed/upgraded/skipped | 见步骤 0 |
-| **5. OpenSpec** | 脚本报告 `openspec` 项 + 三客户端产物状态 | CLI 就绪（脚本报告为准）且所需指令文件存在；`openspec/config.yaml` 缺失仅提示不影响判定 | 按缺失客户端 `init --tools <缺失客户端>` 后 `update` |
+| **5. OpenSpec** | 脚本报告 `openspec` 项 + 四客户端产物状态 | CLI 就绪（脚本报告为准）且所需指令文件存在；`openspec/config.yaml` 缺失仅提示不影响判定 | 按缺失客户端 `init --tools <缺失客户端>` 后 `update` |
 | **6. Superpowers** | `~/.agents/superpowers/skills` | 四层软链同步完成 | 在线 clone；失败时提示离线复制 |
 | **可选. playwright-cli** | 用户明确要求时检查 `playwright-cli --help` | 输出帮助信息 | 自动全局安装并安装 skills |
 | **默认提醒. API Key** | 展示占位配置提醒 | 用户后续自行替换真实密钥 | 不收集、不验证密钥 |
@@ -223,7 +224,7 @@ python3 -c "import json;print(json.load(open('<REPORT>'))['hints']['superpowers_
 **JSON 结构**（权威）：`overall`（success/partial/failed）、`steps[]`（每项 `name`/`status`/`action`/`version`/`error`，status 枚举 ready/installed/upgraded/skipped/failed）、`next_actions`、`hints.superpowers_git`。
 
 **判定规则**：
-- `overall=success` 且六工具 status 均为 ready/installed/upgraded/skipped：基础工具门槛通过，继续步骤 5 的 OpenSpec 三客户端检查与步骤 6 的 Superpowers 同步。
+- `overall=success` 且六工具 status 均为 ready/installed/upgraded/skipped：基础工具门槛通过，继续步骤 5 的 OpenSpec 四客户端检查与步骤 6 的 Superpowers 同步。
 - `overall` 为 `partial` 或 `failed`，或任一 `steps[].status=failed`，或脚本非零退出：no-interrupt 模式立即终止 `/pre-check` 并报告失败；普通模式报告失败项与恢复建议，**不得继续后续步骤，不宣称成功**。
 - pi-mcp-adapter 的 `status=skipped`（action=pi-not-found）不算失败。
 
@@ -263,44 +264,48 @@ ls ~/.claude/skills/playwright-cli
 - **Skills**：安装后 Claude Code 可自动识别并使用 Playwright skills
 - **默认行为**：不安装、不启用；需要时由用户显式要求
 
-### 步骤 5：检查 OpenSpec 三客户端产物
+### 步骤 5：检查 OpenSpec 四客户端产物
 
 > **OpenSpec CLI 就绪以脚本报告为准**：openspec CLI 的探测/安装/复验由步骤 0 脚本统一完成，不再单独执行 `openspec --version`。仅当步骤 0 报告 `steps[]` 中 `name=openspec` 项为就绪（ready/installed/upgraded）时才继续本节；未就绪时先回步骤 0 处理。
 
 **行为（中文输出）**：
-- CLI 已就绪（脚本报告 `openspec` 项为 ready/installed/upgraded）：继续本节三客户端产物检查
-- CLI 未就绪：openspec CLI 由步骤 0 脚本统一安装与验证；本节仅在 CLI 就绪后执行三客户端产物检查
+- CLI 已就绪（脚本报告 `openspec` 项为 ready/installed/upgraded）：继续本节四客户端产物检查
+- CLI 未就绪：openspec CLI 由步骤 0 脚本统一安装与验证；本节仅在 CLI 就绪后执行四客户端产物检查
 - `openspec/config.yaml` 不存在：报告 "✓ openspec/config.yaml 尚未创建，将由 rule-config 步骤 11 创建（含 Cadence 协作规则上下文），不阻塞本检查"
 
-**安装**：openspec CLI 由步骤 0 脚本统一安装与验证（见 `steps[]` 中 `name=openspec` 项）；CLI 未就绪时先回到步骤 0 处理，再继续本节三客户端产物检查。
+**安装**：openspec CLI 由步骤 0 脚本统一安装与验证（见 `steps[]` 中 `name=openspec` 项）；CLI 未就绪时先回到步骤 0 处理，再继续本节四客户端产物检查。
 
 **初始化与更新命令**：
 
 > **执行位置**：`openspec init`/`openspec update` 作用于当前工作目录，产物（`.claude/.codex/.pi`）写入该目录。为在独立 shell 下确保落到项目根，每条命令用 `cd "<PROJECT_ROOT>" && ...` 自包含（`<PROJECT_ROOT>` 为步骤 0 确定的项目根绝对路径字面值）。
 
 ```bash
-# 三客户端产物均缺失（新项目）
-cd "<PROJECT_ROOT>" && openspec init --tools claude,codex,pi
+# 四客户端产物均缺失（新项目）
+cd "<PROJECT_ROOT>" && openspec init --tools claude,codex,pi,kimi
+
+# 仅 kimi 产物缺失
+cd "<PROJECT_ROOT>" && openspec init --tools kimi && openspec update
 
 # 仅 pi 产物缺失
 cd "<PROJECT_ROOT>" && openspec init --tools pi && openspec update
 
-# 三客户端产物齐全
+# 四客户端产物齐全
 cd "<PROJECT_ROOT>" && openspec update
 ```
 
 **增量要求**：
 
-按 claude、codex、pi 三客户端分别检测指令产物存在性，`openspec/config.yaml` 是否存在不作为分支判断条件：
+按 claude、codex、pi、kimi 四客户端分别检测指令产物存在性，`openspec/config.yaml` 是否存在不作为分支判断条件：
 
 | 客户端 | 产物就绪判定 |
 |--------|--------------|
 | claude | `.claude/commands/opsx/` 存在，或 `.claude/skills/` 下存在 `openspec-*` 目录 |
 | codex | `.codex/skills/` 下存在 `openspec-*` 目录 |
 | pi | `.pi/skills/` 下恰有 5 个 `openspec-*` 目录，且 `.pi/prompts/` 下恰有 5 个 `opsx-*.md` 文件 |
+| kimi | `.kimi-code/skills/` 下存在 5 个 `openspec-*` 目录 |
 
-- 存在缺失客户端：对缺失客户端执行 `openspec init --tools <缺失客户端列表>`（如 `claude,codex,pi`、`pi`），再执行 `openspec update`。
-- 三客户端产物均齐全：直接执行 `openspec update`。
+- 存在缺失客户端：对缺失客户端执行 `openspec init --tools <缺失客户端列表>`（如 `claude,codex,pi,kimi`、`pi`、`kimi`），再执行 `openspec update`。
+- 四客户端产物均齐全：直接执行 `openspec update`。
 - 已就绪客户端不得重新 init，不覆盖用户改动。
 - `openspec init` 检测到 `openspec/config.yaml` 已存在时原样保留（CLI 行为），不覆盖 rule-config 写入的内容。
 - `openspec update` 只刷新已初始化的工具产物，不能为未初始化的客户端新增产物；缺失客户端必须由 `openspec init` 补齐。
@@ -308,7 +313,9 @@ cd "<PROJECT_ROOT>" && openspec update
   - Claude Code：`.claude/commands/opsx/`、`.claude/skills/openspec-*`
   - Codex：`.codex/skills/openspec-*`
   - pi：`.pi/prompts/opsx-*`、`.pi/skills/openspec-*`
+  - Kimi Code：`.kimi-code/skills/openspec-*`（无 commands/adapter，仅 5 个 skill）
 - `--tools pi` 需要 OpenSpec CLI >= 1.4.1；步骤 0 脚本始终安装 `@fission-ai/openspec@latest`，版本不足时先回到步骤 0 升级 CLI。
+- `--tools kimi` 需要 OpenSpec CLI >= 1.7.0（生成 `.kimi-code/skills/`；1.4.0 起支持 kimi 但路径为旧 `.kimi/skills/`，1.7.0 起改用 `.kimi-code/` 并自动迁移旧 `.kimi` 配置）；步骤 0 脚本始终安装 `@fission-ai/openspec@latest`，版本不足时先回到步骤 0 升级 CLI。
 - 已存在的 OpenSpec skills 或 commands 不删除、不覆盖用户改动；如 `openspec update` 产生冲突，报告冲突并提示用户手动处理。
 
 **验证命令**：
@@ -319,6 +326,8 @@ cd "<PROJECT_ROOT>" && test -f .claude/commands/opsx/propose.md -o -f .claude/sk
 cd "<PROJECT_ROOT>" && test -f .pi/skills/openspec-propose/SKILL.md
 cd "<PROJECT_ROOT>" && test "$(find .pi/skills -mindepth 1 -maxdepth 1 -type d -name 'openspec-*' | wc -l | tr -d ' ')" = 5
 cd "<PROJECT_ROOT>" && test "$(find .pi/prompts -mindepth 1 -maxdepth 1 -type f -name 'opsx-*.md' | wc -l | tr -d ' ')" = 5
+cd "<PROJECT_ROOT>" && test -f .kimi-code/skills/openspec-propose/SKILL.md
+cd "<PROJECT_ROOT>" && test "$(find .kimi-code/skills -mindepth 1 -maxdepth 1 -type d -name 'openspec-*' | wc -l | tr -d ' ')" = 5
 ```
 
 > 说明：`openspec/config.yaml` 由 rule-config 步骤 11 创建与合并，不属于本检查的完成条件；缺失时仅按"行为（中文输出）"输出提示。

--- a/cadence-init/skills/pre-check/scripts/pre-check.sh
+++ b/cadence-init/skills/pre-check/scripts/pre-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Cadence pre-check 主脚本：六个基础工具的探测/安装/复验。
 # 职责边界：仅处理 npx/uvx/ast-grep/codegraph/openspec/pi-mcp-adapter。
-# 不处理 Superpowers 软链、OpenSpec 三客户端产物、Playwright、API Key（由 SKILL.md 处理）。
+# 不处理 Superpowers 软链、OpenSpec 四客户端产物、Playwright、API Key（由 SKILL.md 处理）。
 # 用法:
 #   pre-check.sh run   [--mirror <name>] [--no-interrupt] [--upgrade]
 #   pre-check.sh check [--mirror <name>] [--no-interrupt]

--- a/cadence-init/skills/rule-config/SKILL.md
+++ b/cadence-init/skills/rule-config/SKILL.md
@@ -82,7 +82,7 @@ python3 "<RULE_CONFIG_PY>" apply --project-root "<PROJECT_ROOT>" --report "<REPO
 
 ```bash
 find . \
-  \( -type d \( -name .git -o -name .claude -o -name .claude-plugin -o -name .codex -o -name .pi -o -name .codegraph -o -name cadence-init -o -name Cadence-skills \
+  \( -type d \( -name .git -o -name .claude -o -name .claude-plugin -o -name .codex -o -name .pi -o -name .kimi-code -o -name .codegraph -o -name cadence-init -o -name Cadence-skills \
     -o -name node_modules -o -name vendor -o -name venv -o -name .venv -o -name env -o -name .env \
     -o -name dist -o -name build -o -name coverage -o -name .next -o -name target -o -name __pycache__ \) -prune \) \
   -o \( -type f \( -name '*.java' -o -name '*.js' -o -name '*.ts' -o -name '*.py' -o -name '*.go' \

--- a/cadence-init/skills/rule-config/scripts/rule-config.py
+++ b/cadence-init/skills/rule-config/scripts/rule-config.py
@@ -354,6 +354,7 @@ PRUNE_DIRS = [
     ".claude-plugin",
     ".codex",
     ".pi",
+    ".kimi-code",
     ".codegraph",
     "cadence-init",
     "Cadence-skills",

--- a/cadence/plans/2026-08-11_计划文档_实施_cadence支持kimi-code第四客户端_v1.0.md
+++ b/cadence/plans/2026-08-11_计划文档_实施_cadence支持kimi-code第四客户端_v1.0.md
@@ -409,7 +409,7 @@ cd /tmp && rm -rf kimi-e2e && mkdir kimi-e2e && cd kimi-e2e
 git init -q && openspec init --tools claude,codex,pi,kimi 2>&1 | tail -5
 # 验证四客户端产物
 test -f .claude/commands/opsx/propose.md -o -f .claude/skills/openspec-propose/SKILL.md
-test -d .codex/skills/openspec-propose
+test -d .agents/skills/openspec-propose
 test -f .pi/skills/openspec-propose/SKILL.md
 test -f .kimi-code/skills/openspec-propose/SKILL.md
 test "$(find .kimi-code/skills -mindepth 1 -maxdepth 1 -type d -name 'openspec-*' | wc -l | tr -d ' ')" = 5

--- a/cadence/plans/2026-08-11_计划文档_实施_cadence支持kimi-code第四客户端_v1.0.md
+++ b/cadence/plans/2026-08-11_计划文档_实施_cadence支持kimi-code第四客户端_v1.0.md
@@ -1,0 +1,481 @@
+# Cadence 支持 Kimi Code 第四客户端实施 Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 cadence-init 的 pre-check / mcp-configuration / rule-config 三 skill 完整支持 Kimi Code 作为第四客户端：OpenSpec 产物四客户端补齐、MCP 原生复用根目录 `.mcp.json`、项目类型扫描剪枝 `.kimi-code`、README 表述同步。
+
+**Architecture:** 改动收敛在三个 skill 的文档与一处脚本常量内：pre-check 步骤 5 从三客户端扩为四客户端（`openspec init --tools claude,codex,pi,kimi`，按缺失客户端增量补齐 kimi）；mcp-configuration 仅补文档（Kimi Code 原生三层加载 MCP 配置，直接复用根目录 `.mcp.json`，不生成第二份配置）；rule-config 在 `PRUNE_DIRS` 常量与 SKILL.md find 块同步加 `.kimi-code`（受 `assert_bounded_source_scan_contract` 双向断言）。Superpowers 四层软链不变（`~/.agents/skills` 通用层已被 Kimi 扫描）。路由规则模板已含 "Claude/Kimi" 表述，不改。
+
+**Tech Stack:** Markdown（SKILL.md/README）、Python 3（rule-config.py 常量）、Shell（pre-check.sh 注释、verify-managed-lifecycle.sh harness）、OpenSpec CLI（>= 1.7.0 生成 `.kimi-code/skills/`）。
+
+**契约映射：** 本 Plan 只展开 `openspec/changes/support-kimi-code/tasks.md` 的 6 组工作包，不重定义范围、架构或验收。验收 Scenario 以 `specs/kimi-code-support/spec.md` 与 `specs/init-skill-sequencing/spec.md`（delta）为准。
+
+## Global Constraints
+
+- 本仓库根目录 `AGENTS.md` 与 `.claude/rules/` 为受管文件，本次**不改动**（路由规则模板 `agent-routing-kernel.md` / `openspec-superpowers-workflow.md` 已含 "Claude/Kimi"，保持不变）。
+- `install-offline.sh/.bat`、`.claude-plugin/` 与 Claude Code 插件打包**不改动**（与客户端支持无关）。
+- Superpowers 软链层数与逻辑**不改动**（Kimi 经 `~/.agents/skills` 通用层消费，不新增 `~/.kimi-code/skills` 软链目标）。
+- mcp-configuration **不生成 `.kimi-code/mcp.json` 副本**、**不新增 `.gitignore` 条目**（Kimi 原生读取根目录 `.mcp.json`；`.mcp.json` 已在忽略清单）。
+- OpenSpec 版本注记：`--tools kimi` 生成 `.kimi-code/skills/` 需要 OpenSpec CLI >= **1.7.0**（1.4.0 起支持 kimi 但产物路径为旧 `.kimi/skills/`；1.7.0 起改为 `.kimi-code/` 并自动迁移旧 `.kimi` 配置）。pre-check 脚本始终安装 `@fission-ai/openspec@latest`，版本不足按既有升级逻辑处理。
+- 所有文档中文；Markdown 遵循 `.claude/rules/markdown-format.md`。
+- 每个 Task 结束独立提交，提交信息遵循仓库既有风格（`feat(pre-check):` / `docs(mcp-configuration):` / `fix(rule-config):` / `docs(readme):`）。
+
+---
+
+### Task 1: pre-check SKILL.md —— OpenSpec 四客户端产物（契约工作包 1.1–1.6）
+
+**Files:**
+- Modify: `cadence-init/skills/pre-check/SKILL.md`
+
+**Interfaces:**
+- Consumes: 无（纯文档编排）。
+- Produces: `openspec init --tools claude,codex,pi,kimi` 四客户端命令与 kimi 就绪判定口径，供 Task 6 端到端验证引用。
+
+- [ ] **Step 1: 更新 no-interrupt 强制完成策略表（第 44 行）**
+
+将：
+```
+| OpenSpec 三客户端产物 | claude/codex/pi 三客户端目标指令文件验证成功（`openspec/config.yaml` 缺失不算失败，仅提示由 rule-config 创建） | 立即终止 |
+```
+改为：
+```
+| OpenSpec 四客户端产物 | claude/codex/pi/kimi 四客户端目标指令文件验证成功（`openspec/config.yaml` 缺失不算失败，仅提示由 rule-config 创建） | 立即终止 |
+```
+
+- [ ] **Step 2: 更新增量运行示例（第 127 行）**
+
+在现有"框架新增 OpenSpec pi 支持后…"段落后追加 kimi 段落，并把新项目命令改为四客户端：
+```
+- 框架新增 OpenSpec kimi 支持后，老项目重新运行 `/pre-check`：缺少 `.kimi-code` 产物时先执行 `openspec init --tools kimi`，再执行 `openspec update`；若 kimi 产物已存在，则直接执行 `openspec update`。新项目或四客户端产物均缺失时执行 `openspec init --tools claude,codex,pi,kimi`。
+```
+并将原文"新项目或三客户端产物均缺失时执行 `openspec init --tools claude,codex,pi`"改为四客户端命令。
+
+- [ ] **Step 3: 更新检查流程图 label（第 143 行）**
+
+`openspec_clients [label="步骤 5：OpenSpec 三客户端产物补齐"];` → `openspec_clients [label="步骤 5：OpenSpec 四客户端产物补齐"];`
+
+- [ ] **Step 4: 更新快速参考表（第 167 行）**
+
+`| **5. OpenSpec** | 脚本报告 `openspec` 项 + 三客户端产物状态 | ... | 按缺失客户端 `init --tools <缺失客户端>` 后 `update` |`
+→ 将"三客户端产物状态"改为"四客户端产物状态"。
+
+- [ ] **Step 5: 更新步骤 0 判定规则（第 226 行）**
+
+`...继续步骤 5 的 OpenSpec 三客户端检查与步骤 6 的 Superpowers 同步。` → `...继续步骤 5 的 OpenSpec 四客户端检查与步骤 6 的 Superpowers 同步。`
+
+- [ ] **Step 6: 更新步骤 5 标题与行为说明（第 266–275 行）**
+
+- 标题：`### 步骤 5：检查 OpenSpec 三客户端产物` → `### 步骤 5：检查 OpenSpec 四客户端产物`
+- 三处"三客户端产物检查"（第 271、272、275 行）→ "四客户端产物检查"
+- 第 271 行"继续本节三客户端产物检查"与第 272 行"本节仅在 CLI 就绪后执行三客户端产物检查"同步替换。
+
+- [ ] **Step 7: 更新初始化与更新命令（第 282–288 行）**
+
+```bash
+# 四客户端产物均缺失（新项目）
+cd "<PROJECT_ROOT>" && openspec init --tools claude,codex,pi,kimi
+
+# 仅 kimi 产物缺失
+cd "<PROJECT_ROOT>" && openspec init --tools kimi && openspec update
+
+# 仅 pi 产物缺失
+cd "<PROJECT_ROOT>" && openspec init --tools pi && openspec update
+
+# 四客户端产物齐全
+cd "<PROJECT_ROOT>" && openspec update
+```
+
+- [ ] **Step 8: 更新增量要求表与验证命令（第 294–315 行）**
+
+- 表头"按 claude、codex、pi 三客户端分别检测指令产物存在性" → "按 claude、codex、pi、kimi 四客户端分别检测指令产物存在性"。
+- 表中新增 kimi 行：
+```
+| kimi | `.kimi-code/skills/` 下存在 5 个 `openspec-*` 目录 |
+```
+- 第 302 行"存在缺失客户端：…（如 `claude,codex,pi`、`pi`）"补充 `kimi` 示例。
+- 第 303 行"三客户端产物均齐全" → "四客户端产物均齐全"。
+- 产物结构说明补充：
+```
+  - Kimi Code：`.kimi-code/skills/openspec-*`（无 commands/adapter，仅 5 个 skill）
+```
+- 验证命令追加：
+```bash
+cd "<PROJECT_ROOT>" && test -f .kimi-code/skills/openspec-propose/SKILL.md
+cd "<PROJECT_ROOT>" && test "$(find .kimi-code/skills -mindepth 1 -maxdepth 1 -type d -name 'openspec-*' | wc -l | tr -d ' ')" = 5
+```
+
+- [ ] **Step 9: 补充版本注记（步骤 5 尾部）**
+
+在 `--tools pi 需要 OpenSpec CLI >= 1.4.1` 注记附近追加：
+```
+- `--tools kimi` 需要 OpenSpec CLI >= 1.7.0（生成 `.kimi-code/skills/`；1.4.0 起支持 kimi 但路径为旧 `.kimi/skills/`，1.7.0 起改用 `.kimi-code/` 并自动迁移旧 `.kimi` 配置）；步骤 0 脚本始终安装 `@fission-ai/openspec@latest`，版本不足时先回到步骤 0 升级 CLI。
+```
+确认既有 `--tools pi 需要 OpenSpec CLI >= 1.4.1` 注记原样保留。
+
+- [ ] **Step 10: 验证（grep 断言无残留"三客户端"）**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+# 应无输出（0 命中）
+grep -n "三客户端" cadence-init/skills/pre-check/SKILL.md
+# 应命中 4 处及以上
+grep -c "claude,codex,pi,kimi" cadence-init/skills/pre-check/SKILL.md
+# 应命中 kimi 就绪判定与验证命令
+grep -n "kimi" cadence-init/skills/pre-check/SKILL.md
+```
+预期：`grep "三客户端"` 无命中；`claude,codex,pi,kimi` 至少 2 处；`kimi` 覆盖就绪判定表、增量表、验证命令、版本注记。
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+git add cadence-init/skills/pre-check/SKILL.md
+git commit -m "feat(pre-check): OpenSpec 客户端产物扩为四客户端（claude/codex/pi/kimi）"
+```
+
+---
+
+### Task 2: pre-check —— 脚本注释 + Superpowers 覆盖说明（契约工作包 1.7、2.1）
+
+**Files:**
+- Modify: `cadence-init/skills/pre-check/scripts/pre-check.sh`（第 4 行注释）
+- Modify: `cadence-init/skills/pre-check/SKILL.md`（步骤 6 Superpowers 目录约定）
+
+**Interfaces:**
+- Consumes: Task 1 已确立四客户端口径。
+- Produces: "Kimi 经 `~/.agents/skills` 通用层消费、无额外同步层"的文档口径，供 Task 3/5 复用表述。
+
+- [ ] **Step 1: 更新 pre-check.sh 头部职责注释（第 4 行）**
+
+将：
+```
+# 不处理 Superpowers 软链、OpenSpec 三客户端产物、Playwright、API Key（由 SKILL.md 处理）。
+```
+改为：
+```
+# 不处理 Superpowers 软链、OpenSpec 四客户端产物、Playwright、API Key（由 SKILL.md 处理）。
+```
+（仅注释，无逻辑改动。）
+
+- [ ] **Step 2: 在 SKILL.md 步骤 6 目录约定表后追加说明**
+
+在步骤 6 的"目录约定"表下方追加：
+```
+> 说明：Kimi Code 扫描用户级通用目录 `~/.agents/skills`（superpowers 软链第 2 层即此目录），经该层直接获得 Superpowers skills，无需新增 `~/.kimi-code/skills` 软链目标；`~/.kimi-code/skills` 是 Kimi 专属用户 skills 目录，不放通用 superpowers。
+```
+
+- [ ] **Step 3: 验证**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+grep -n "四客户端产物" cadence-init/skills/pre-check/scripts/pre-check.sh
+grep -n "Kimi Code 扫描用户级通用目录" cadence-init/skills/pre-check/SKILL.md
+# 确认 SKILL.md 步骤 6 目录约定表不含 ~/.kimi-code/skills 软链目标
+grep -c "\.kimi-code/skills" cadence-init/skills/pre-check/SKILL.md
+```
+预期：脚本注释命中 1 处；SKILL.md 说明命中 1 处；`.kimi-code/skills` 仅出现在说明文字（不含"软链目标"表述）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+git add cadence-init/skills/pre-check/scripts/pre-check.sh cadence-init/skills/pre-check/SKILL.md
+git commit -m "docs(pre-check): Superpowers 覆盖 Kimi 说明 + 脚本职责注释四客户端"
+```
+
+---
+
+### Task 3: mcp-configuration —— Kimi 复用根目录 `.mcp.json`（契约工作包 3.1–3.4）
+
+**Files:**
+- Modify: `cadence-init/skills/mcp-configuration/SKILL.md`
+
+**Interfaces:**
+- Consumes: Task 2 的"Kimi 经通用层消费"表述风格。
+- Produces: 客户端格式差异表 Kimi 列 + Kimi MCP 说明节，供 Task 5 README 同步引用。
+
+- [ ] **Step 1: 更新概述（第 11 行）**
+
+在现有概述段落后追加一句：
+```
+Kimi Code 原生读取项目根 `.mcp.json`（三层加载：`~/.kimi-code/mcp.json` → `<项目根>/.mcp.json` → `<cwd>/.kimi-code/mcp.json`，后者覆盖前者），本 Skill 维护的 `.mcp.json` 即 Kimi 的 MCP 配置来源，无需同步第二份配置。
+```
+
+- [ ] **Step 2: 更新检查清单（第 110 行区域）**
+
+在清单第 6 项"pi MCP 说明"后追加：
+```
+7. **Kimi MCP 说明** — 说明 Kimi Code 原生读取项目根 `.mcp.json`（含 stdio/HTTP/SSE），不维护第二份配置
+8. **配置 .gitignore** — 添加 `.worktrees/`、`.mcp.json` 和 `.codex/config.toml` 到 .gitignore（Kimi 复用 `.mcp.json`，无需新增条目）
+```
+（原"7. 配置 .gitignore"编号顺延为 8。）
+
+- [ ] **Step 3: 更新客户端格式差异表（第 562 行）**
+
+表头 `**Claude Code、Codex 与 pi 格式差异**` → `**Claude Code、Codex、pi 与 Kimi Code 格式差异**`，表体追加一列并补一行：
+
+| 特征 | Claude Code (`.mcp.json`) | Codex (`.codex/config.toml`) | pi（pi-mcp-adapter） | Kimi Code（原生） |
+|------|--------------------------|------------------------------|----------------------|-------------------|
+| 格式 | JSON | TOML | 复用 `.mcp.json`（JSON），无第二份配置 | 复用根目录 `.mcp.json`（JSON），无第二份配置 |
+| 服务器定义 | `"mcpServers": { "name": {...} }` | `[mcp_servers.name]` | 同 `.mcp.json` | 同 `.mcp.json` |
+| 传输类型 | `"type": "stdio"` / `"type": "http"` | 仅 stdio（有 `command`），**HTTP 类型不支持** | stdio 与 HTTP 均支持 | stdio / HTTP / SSE 均支持 |
+| 环境变量 | `"env": { "KEY": "value" }` | `env = { "KEY" = "value" }` | 同 `.mcp.json` | 同 `.mcp.json` |
+| HTTP 头 | `"headers": { "Authorization": "..." }` | `http_headers = { "Authorization" = "..." }` | 同 `.mcp.json` | 同 `.mcp.json` |
+| type 字段 | 必须显式声明 | 不需要（自动推断） | 同 `.mcp.json` | 不需要（按 `command`/`url` 自动推断） |
+
+> 说明：Kimi 的 schema 为非严格解析，`.mcp.json` 中 pi 扩展的 `directTools` 等未知字段会被静默忽略，无需为 Kimi 剥离。
+
+- [ ] **Step 4: 新增 "### 7.5 Kimi Code MCP 说明" 节（插在 pi 节之后、.gitignore 节之前）**
+
+```markdown
+### 7.5 Kimi Code MCP 说明
+
+> **无需同步步骤** — Kimi Code 不维护第二份 MCP 配置文件。
+
+- Kimi Code 原生支持 MCP（stdio / HTTP / SSE 三种传输），直接读取项目根目录 `.mcp.json`（源码三层加载：`~/.kimi-code/mcp.json` → `<项目根>/.mcp.json` → `<cwd>/.kimi-code/mcp.json`，后者覆盖前者）。
+- 本 Skill 维护的 `.mcp.json` 即 Kimi 的 MCP 配置来源：智普的 `web-search-prime`、`web-reader`、`zread`（HTTP）与 `zai-mcp-server`、MiniMax（stdio）在 Kimi 下均可用，无需任何同步。
+- `.mcp.json` 中的 `directTools` 等 pi 扩展字段对 Kimi 无害（非严格 schema 静默忽略）。
+- `.gitignore` 无需新增条目：Kimi 复用的 `.mcp.json` 已在忽略清单内。
+
+**Kimi 侧验证方式**：Kimi Code 会话中输入 `/mcp` 查看 server 连接状态，输入 `/mcp-config` 交互式新增/编辑/删除 server。
+```
+
+- [ ] **Step 5: 验证**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+grep -n "Kimi Code MCP 说明\|Kimi Code（原生）\|kimi-code/mcp.json" cadence-init/skills/mcp-configuration/SKILL.md
+# 确认全文没有"为 Kimi 生成 .kimi-code/mcp.json 副本"或"追加 .kimi-code/mcp.json"类指令
+grep -n "追加 .kimi-code/mcp.json" cadence-init/skills/mcp-configuration/SKILL.md
+```
+预期：Kimi 说明节、格式差异表 Kimi 列、三层加载说明均命中；`追加 .kimi-code/mcp.json` 无命中。
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+git add cadence-init/skills/mcp-configuration/SKILL.md
+git commit -m "docs(mcp-configuration): Kimi Code 原生复用根目录 .mcp.json"
+```
+
+---
+
+### Task 4: rule-config —— 项目类型扫描剪枝 `.kimi-code`（契约工作包 4.1–4.3）
+
+**Files:**
+- Modify: `cadence-init/skills/rule-config/scripts/rule-config.py`（`PRUNE_DIRS` 常量，约 351–372 行）
+- Modify: `cadence-init/skills/rule-config/SKILL.md`（有界扫描 find 块，第 85–86 行）
+- Test: `cadence-init/skills/rule-config/tests/verify-managed-lifecycle.sh`（`assert_bounded_source_scan_contract` 双向断言，自动覆盖）
+
+**Interfaces:**
+- Consumes: 无。
+- Produces: `PRUNE_DIRS` 含 `.kimi-code`，且与 SKILL.md find 块双向一致（harness 断言强制）。
+
+- [ ] **Step 1: 在 `rule-config.py` 的 `PRUNE_DIRS` 增加 `.kimi-code`**
+
+在 `PRUNE_DIRS` 列表的 `".pi",` 行之后插入 `".kimi-code",`：
+```python
+PRUNE_DIRS = [
+    ".git",
+    ".claude",
+    ".claude-plugin",
+    ".codex",
+    ".pi",
+    ".kimi-code",
+    ".codegraph",
+    "cadence-init",
+    "Cadence-skills",
+    "node_modules",
+    "vendor",
+    "venv",
+    ".venv",
+    "env",
+    ".env",
+    "dist",
+    "build",
+    "coverage",
+    ".next",
+    "target",
+    "__pycache__",
+]
+```
+
+- [ ] **Step 2: 在 SKILL.md 有界扫描 find 块同步增加 `-o -name .kimi-code`**
+
+将第 85 行：
+```
+  \( -type d \( -name .git -o -name .claude -o -name .claude-plugin -o -name .codex -o -name .pi -o -name .codegraph -o -name cadence-init -o -name Cadence-skills \
+```
+改为：
+```
+  \( -type d \( -name .git -o -name .claude -o -name .claude-plugin -o -name .codex -o -name .pi -o -name .kimi-code -o -name .codegraph -o -name cadence-init -o -name Cadence-skills \
+```
+（其余行不动；SKILL.md 注释"与脚本 `PRUNE_DIRS` 常量逐项一致，不得增删"保持原样。）
+
+- [ ] **Step 3: 运行单元测试确认无回归**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills/cadence-init/skills/rule-config/tests
+python3 -m unittest test_rule_config -v 2>&1 | tail -5
+```
+预期：全部测试通过（含 `ut-detect_project-bounded-scan / S1a-01` 剪枝用例）。
+
+- [ ] **Step 4: 运行 harness 双向断言**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills/cadence-init/skills/rule-config/tests
+bash verify-managed-lifecycle.sh 2>&1 | tail -15
+```
+预期：`assert_bounded_source_scan_contract` 通过（脚本 `PRUNE_DIRS` 与 SKILL.md find 剪枝清单逐项一致），整体 exit 0。
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+git add cadence-init/skills/rule-config/scripts/rule-config.py cadence-init/skills/rule-config/SKILL.md
+git commit -m "fix(rule-config): 项目类型扫描剪枝 .kimi-code 客户端目录"
+```
+
+---
+
+### Task 5: README 与文档四客户端表述（契约工作包 5.1–5.3）
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: Task 1 的四客户端口径、Task 3 的 Kimi MCP 说明。
+- Produces: 对外文档四客户端口径，供最终验收对照。
+
+- [ ] **Step 1: 更新 skills 表格 `/pre-check` 行（第 217 行）**
+
+将 `OpenSpec 检查范围为 CLI 与 `claude,codex,pi` 三客户端指令产物` → `OpenSpec 检查范围为 CLI 与 `claude,codex,pi,kimi` 四客户端指令产物`。
+
+- [ ] **Step 2: 更新 no-interrupt 表格 `/pre-check` 行（第 320 行）**
+
+`OpenSpec（CLI 与三客户端指令产物；...）` → `OpenSpec（CLI 与四客户端指令产物；...）`。
+
+- [ ] **Step 3: 更新职责边界说明（第 338 行）**
+
+`/pre-check` 负责 OpenSpec CLI 与三客户端指令产物 → 四客户端指令产物。
+
+- [ ] **Step 4: 更新初始化特性列表（第 368 行）**
+
+`OpenSpec 检查 CLI 与 `claude,codex,pi` 三客户端指令产物` → `OpenSpec 检查 CLI 与 `claude,codex,pi,kimi` 四客户端指令产物`。
+
+- [ ] **Step 5: 更新客户端支持说明（第 519 行）**
+
+`同时支持 Claude Code、Codex 与 pi 三类客户端的环境初始化` → `同时支持 Claude Code、Codex、pi 与 Kimi Code 四类客户端的环境初始化`。
+
+- [ ] **Step 6: 更新 `/mcp-configuration` 行（第 220 行）**
+
+在现有描述后追加 `Kimi Code 原生复用根目录 `.mcp.json`（含 HTTP server），不维护第二份配置`。
+
+- [ ] **Step 7: 验证**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+# 应无输出（0 命中）
+grep -n "三客户端" README.md
+# 应命中 4 处
+grep -c "四客户端" README.md
+grep -n "Kimi Code" README.md | head
+```
+预期：`三客户端` 无残留；`四客户端` 至少 4 处；Kimi Code 说明覆盖 skills 表格与支持说明。
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills
+git add README.md
+git commit -m "docs(readme): 客户端支持扩为四客户端并补充 Kimi Code 说明"
+```
+
+---
+
+### Task 6: 端到端验证（契约工作包 6.1–6.3）
+
+**Files:**
+- 临时目录（验证用，不入库）：`/tmp/kimi-e2e-XXXXXX`
+
+**Interfaces:**
+- Consumes: Task 1–5 全部产物。
+- Produces: 四客户端产物、`.mcp.json` Kimi 消费、PRUNE_DIRS 无回归的新鲜证据。
+
+- [ ] **Step 1: 临时项目验证 OpenSpec 四客户端产物**
+
+```bash
+cd /tmp && rm -rf kimi-e2e && mkdir kimi-e2e && cd kimi-e2e
+git init -q && openspec init --tools claude,codex,pi,kimi 2>&1 | tail -5
+# 验证四客户端产物
+test -f .claude/commands/opsx/propose.md -o -f .claude/skills/openspec-propose/SKILL.md
+test -d .codex/skills/openspec-propose
+test -f .pi/skills/openspec-propose/SKILL.md
+test -f .kimi-code/skills/openspec-propose/SKILL.md
+test "$(find .kimi-code/skills -mindepth 1 -maxdepth 1 -type d -name 'openspec-*' | wc -l | tr -d ' ')" = 5
+echo "E2E-OK"
+```
+预期：`openspec init` 成功输出 "Created: Kimi Code / 5 skills in .kimi-code/"；四个 `test` 全部通过，输出 `E2E-OK`。
+
+- [ ] **Step 2: 增量补齐验证（老项目缺 kimi）**
+
+```bash
+cd /tmp && rm -rf kimi-incremental && mkdir kimi-incremental && cd kimi-incremental
+git init -q && openspec init --tools claude,codex,pi 2>&1 | tail -2
+# 模拟老项目：无 .kimi-code，验证仅 init kimi 后 update
+openspec init --tools kimi 2>&1 | tail -3
+openspec update 2>&1 | tail -2
+test -f .kimi-code/skills/openspec-propose/SKILL.md && echo "INCR-OK"
+```
+预期：老项目仅执行 `init --tools kimi` + `update` 后补齐 `.kimi-code/skills/openspec-*`，输出 `INCR-OK`。
+
+- [ ] **Step 3: rule-config 测试套件与 harness 全量回归**
+
+```bash
+cd /home/michaelche/workspace/github/Cadence-skills/cadence-init/skills/rule-config/tests
+python3 -m unittest test_rule_config -v 2>&1 | tail -3
+bash verify-managed-lifecycle.sh 2>&1 | tail -3
+```
+预期：unittest 全部通过；harness exit 0（含 `assert_bounded_source_scan_contract`）。
+
+- [ ] **Step 4: mcp-configuration 冒烟（Kimi 消费 `.mcp.json`）**
+
+```bash
+cd /tmp/kimi-e2e
+# 构造与 mcp-configuration 产物一致的根目录 .mcp.json（含 stdio + HTTP）
+cat > .mcp.json <<'EOF'
+{
+  "mcpServers": {
+    "time": { "command": "uvx", "args": ["mcp-server-time", "--local-timezone=Asia/Shanghai"] },
+    "web-search-prime": { "type": "http", "url": "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp", "headers": { "Authorization": "Bearer your_zhipu_api_key" } }
+  }
+}
+EOF
+# 确认 README/SKILL 文档口径：Kimi 复用此文件，无需第二份配置
+grep -n "Kimi Code 原生读取项目根" /home/michaelche/workspace/github/Cadence-skills/cadence-init/skills/mcp-configuration/SKILL.md
+grep -n "直接读取项目根目录" /home/michaelche/workspace/github/Cadence-skills/cadence-init/skills/mcp-configuration/SKILL.md
+```
+预期：mcp-configuration SKILL.md 存在 Kimi 复用 `.mcp.json` 的口径说明；临时项目无需生成 `.kimi-code/mcp.json`。
+
+- [ ] **Step 5: 清理临时目录并核对提交历史**
+
+```bash
+rm -rf /tmp/kimi-e2e /tmp/kimi-incremental /tmp/openspec-repo
+cd /home/michaelche/workspace/github/Cadence-skills
+git log --oneline -6
+git status --short
+```
+预期：5 个功能提交（Task 1–5）按序出现在 `git log`；`git status` 干净（无未提交改动；`openspec/changes/support-kimi-code/` 为本 change 规划产物，按仓库流程在归档前保留）。
+
+---
+
+## 验收对照（spec → task）
+
+| spec 需求（kimi-code-support / init-skill-sequencing delta） | 覆盖 Task |
+|---|---|
+| OpenSpec 初始化包含 kimi 工具（四客户端 init、增量补齐、就绪判定、验证命令） | Task 1、Task 6 Step 1–2 |
+| Superpowers 说明 kimi 消费方式（不加层、`~/.agents/skills` 覆盖） | Task 2 |
+| MCP 配置说明 kimi 消费方式（复用根目录 `.mcp.json`、不生成副本、gitignore 不加条目） | Task 3、Task 6 Step 4 |
+| 项目类型扫描剪枝 kimi 目录（PRUNE_DIRS + find 块双向一致） | Task 4、Task 6 Step 3 |
+| README 与文档四客户端表述 | Task 5 |
+| init-skill-sequencing：完成门槛/增量补齐/硬门槛/README 口径四客户端 | Task 1、Task 5 |

--- a/openspec/changes/support-kimi-code/.openspec.yaml
+++ b/openspec/changes/support-kimi-code/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/support-kimi-code/design.md
+++ b/openspec/changes/support-kimi-code/design.md
@@ -1,0 +1,60 @@
+# Design: 支持 Kimi Code 第四客户端
+
+## Context
+
+动机见 proposal.md（Why）。当前 cadence-init 只覆盖 Claude Code、Codex、pi 三客户端：pre-check 步骤 5 对 OpenSpec 做三客户端产物补齐、mcp-configuration 只同步 `.mcp.json` 与 `.codex/config.toml`、rule-config 项目类型扫描剪枝 `.claude/.codex/.pi`。经勘察确认：OpenSpec CLI 1.8.0 已原生支持 `--tools kimi`（生成 `.kimi-code/skills/openspec-*` 5 个 SKILL.md，无 commands/adapter）；Kimi Code 读取项目根 `AGENTS.md`（rule-config 已生成且路由规则已含 "Claude/Kimi" 表述）、项目级 `.kimi-code/skills/` 与 `.kimi-code/mcp.json`（JSON `mcpServers` 结构，支持 stdio/HTTP/SSE）、并扫描用户级通用 `~/.agents/skills`。
+
+## Goals / Non-Goals
+
+**Goals**
+- pre-check 将 OpenSpec 产物检查扩为四客户端，老项目重跑自动补齐 kimi 产物。
+- mcp-configuration 为 Kimi 生成项目级 `.kimi-code/mcp.json` 并纳入 `.gitignore`。
+- rule-config 项目类型扫描剪枝 `.kimi-code`。
+- README 与 skills 文档以四客户端口径更新。
+
+**Non-Goals**
+- 不为 Kimi 新增 Superpowers 软链层（复用 `~/.agents/skills` 通用层）。
+- 不修改路由规则模板的 "Claude/Kimi" 表述（Kimi 与 Claude 同为原生 Skill 调用机制，已被现有规则覆盖）。
+- 不复制 `.claude/rules/` 规则文件到 `.kimi-code/`（Kimi 读 AGENTS.md，经摘要引用可达，与 Codex 同处境）。
+- 不为 Kimi 生成 `.kimi-code/mcp.json` 副本（Kimi 原生读取根目录 `.mcp.json`，与 pi 同源复用但无需 adapter）。
+- 不改动 install-offline.sh/.bat（仅 Claude Code 插件安装，与客户端无关）。
+
+## Decisions
+
+### D1: OpenSpec 四客户端"始终补齐"策略
+新项目 `openspec init --tools claude,codex,pi,kimi`；按客户端增量检测，缺失 kimi 时 `openspec init --tools kimi` 再 `update`。
+- **理由**：与现有 claude/codex/pi 三客户端"始终 init"策略一致；kimi 产物是否生成不依赖本机是否安装 Kimi CLI，保证任意环境产物完整、老项目重跑自动补齐。
+- **替代方案（否决）**：检测 `command -v kimi` 才 init——产物完整性依赖本机环境，后续安装 Kimi 需重跑，且与三客户端现有语义不一致。
+
+### D2: Superpowers 不加第五层
+四层软链不变，文档注明 `~/.agents/skills` 通用层已被 Kimi 扫描。
+- **理由**：Kimi 默认 `merge_all_available_skills=true` 合并所有目录，若再软链到 `~/.kimi-code/skills` 会造成同名 skill 双目录注册冗余；且 `~/.kimi-code/skills` 语义是 Kimi 专属用户 skills，放通用 superpowers 会污染其语义。
+- **替代方案（否决）**：类比 pi 的显式第五层——对 Kimi 产生双目录扫描冗余，风险大于收益。
+
+### D3: MCP 配置复用根目录 `.mcp.json`，不生成第二份配置
+- **理由**：Kimi Code 原生三层加载 MCP 配置——`~/.kimi-code/mcp.json`（用户级）、`<项目根>/.mcp.json`（Claude 兼容根目录文件）、`<cwd>/.kimi-code/mcp.json`（Kimi 专属层，优先级最高）。mcp-configuration 已生成根目录 `.mcp.json`，Kimi 直接消费（含 stdio/HTTP/SSE），无需 `.kimi-code/mcp.json` 副本，`.gitignore` 也无需新增条目。
+- **字段兼容**：Kimi 的 `McpServerConfigSchema` 为非严格 zod object（preprocess 按 `command`/`url` 推断 transport），`.mcp.json` 中 pi 扩展的 `directTools` 等未知字段被静默剥离，对 Kimi 无害，无需专门处理。
+- **替代方案（否决）**：生成 `.kimi-code/mcp.json` 副本——冗余，且与用户确认的"Kimi 直接读根目录 mcp.json"事实不符。
+
+### D4: 规则文件不复制、路由规则不改
+- Kimi Code 读取项目根 `AGENTS.md`，rule-config 已生成；AGENTS.md 的摘要引用指向 `.claude/rules/*.md`，Kimi 可经文件工具读取（与 Codex 同处境）。
+- 路由规则模板 `agent-routing-kernel.md` / `openspec-superpowers-workflow.md` 已用 "Claude/Kimi" 类别定义原生 Skill 调用行为，本次不动。
+
+### D5: PRUNE_DIRS 加 `.kimi-code`
+- 与 `.claude/.codex/.pi` 同模式，`scripts/rule-config.py` 的 `PRUNE_DIRS` 常量与 SKILL.md find 块两处同步，受 `assert_bounded_source_scan_contract` 断言核对。
+
+## Risks / Trade-offs
+
+- **OpenSpec `--tools kimi` 最低版本未知** → 实现时查证 changelog，在 SKILL.md 标注与 pi 的 ">= 1.4.1" 同款版本注记；pre-check 脚本始终安装 `@fission-ai/openspec@latest`，版本不足时按现有逻辑升级。
+- **Kimi 解析 OpenSpec 生成 SKILL.md 的非标准 frontmatter 字段**（`allowed-tools`/`license`/`metadata`）→ Kimi 目录形式仅强制 `name`/`description`，未知字段忽略；OpenSpec 官方支持 kimi 工具即保证兼容；实现时对生成的 5 个 SKILL.md 做一次解析冒烟验证。
+- **`.kimi-code/mcp.json` 含 API Key 占位** → 纳入 `.gitignore`，与 `.mcp.json`/`.codex/config.toml` 同策略；文档保留安全提醒。
+- **老项目三客户端产物齐全但无 kimi 产物** → 重跑 `/pre-check` 按增量逻辑仅 `init --tools kimi`，不触碰既有产物。
+
+## Migration Plan
+
+- 老项目：重跑 `/pre-check`（自动补齐 `.kimi-code/skills/openspec-*`）与 `/mcp-configuration`（生成 `.kimi-code/mcp.json`、追加 `.gitignore`）。
+- 回滚：改动均为增量补写，不覆盖既有文件；删除新增条目即回退，无需专门回滚流程。
+
+## Open Questions
+
+无（`--tools kimi` 最低版本属实现时查证项，不影响契约、方案或任务拆分）。

--- a/openspec/changes/support-kimi-code/design.md
+++ b/openspec/changes/support-kimi-code/design.md
@@ -8,7 +8,7 @@
 
 **Goals**
 - pre-check 将 OpenSpec 产物检查扩为四客户端，老项目重跑自动补齐 kimi 产物。
-- mcp-configuration 为 Kimi 生成项目级 `.kimi-code/mcp.json` 并纳入 `.gitignore`。
+- mcp-configuration 补充 Kimi 消费方式说明（Kimi 原生读取根目录 `.mcp.json`），不生成第二份配置，不新增 `.gitignore` 条目。
 - rule-config 项目类型扫描剪枝 `.kimi-code`。
 - README 与 skills 文档以四客户端口径更新。
 
@@ -47,12 +47,12 @@
 
 - **OpenSpec `--tools kimi` 最低版本未知** → 实现时查证 changelog，在 SKILL.md 标注与 pi 的 ">= 1.4.1" 同款版本注记；pre-check 脚本始终安装 `@fission-ai/openspec@latest`，版本不足时按现有逻辑升级。
 - **Kimi 解析 OpenSpec 生成 SKILL.md 的非标准 frontmatter 字段**（`allowed-tools`/`license`/`metadata`）→ Kimi 目录形式仅强制 `name`/`description`，未知字段忽略；OpenSpec 官方支持 kimi 工具即保证兼容；实现时对生成的 5 个 SKILL.md 做一次解析冒烟验证。
-- **`.kimi-code/mcp.json` 含 API Key 占位** → 纳入 `.gitignore`，与 `.mcp.json`/`.codex/config.toml` 同策略；文档保留安全提醒。
+- **`.mcp.json` 含 API Key 占位** → 已入 `.gitignore`；Kimi 与 pi 均复用同一文件，无需额外配置副本或忽略条目。
 - **老项目三客户端产物齐全但无 kimi 产物** → 重跑 `/pre-check` 按增量逻辑仅 `init --tools kimi`，不触碰既有产物。
 
 ## Migration Plan
 
-- 老项目：重跑 `/pre-check`（自动补齐 `.kimi-code/skills/openspec-*`）与 `/mcp-configuration`（生成 `.kimi-code/mcp.json`、追加 `.gitignore`）。
+- 老项目：重跑 `/pre-check`（自动补齐 `.kimi-code/skills/openspec-*`）；MCP 配置无需额外动作（Kimi 与 pi 均原生复用已有根目录 `.mcp.json`）。
 - 回滚：改动均为增量补写，不覆盖既有文件；删除新增条目即回退，无需专门回滚流程。
 
 ## Open Questions

--- a/openspec/changes/support-kimi-code/proposal.md
+++ b/openspec/changes/support-kimi-code/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Cadence 目前只对 Claude Code、Codex、pi 三客户端做环境初始化（OpenSpec 产物、Superpowers 软链、MCP 接入），尚不支持 Kimi Code。OpenSpec CLI 1.8.0 已原生支持 `--tools kimi`（生成 `.kimi-code/skills/openspec-*`），且 Kimi Code 读取项目根 `AGENTS.md`、`.kimi-code/skills/` 与 `.kimi-code/mcp.json`，补齐第四客户端支持的时机已成熟。
+
+## What Changes
+
+- **pre-check**：OpenSpec 检查从三客户端（`claude,codex,pi`）扩为四客户端（`claude,codex,pi,kimi`）。新项目初始化使用 `openspec init --tools claude,codex,pi,kimi`；按客户端增量补齐含 kimi（就绪判定为 `.kimi-code/skills/` 下存在 5 个 `openspec-*` 目录）；验证命令、no-interrupt 门槛、流程与快速参考同步更新。同时纠正 codex 就绪判定、目录结构说明与验证命令的产物路径：最新 OpenSpec 为 skills-only，codex 产物落项目根 `.agents/skills/openspec-*`（不再产生 `.codex/`），故 codex 判定从 `.codex/skills/` 改为 `.agents/skills/`。Superpowers 四层软链不变，文档明确 `~/.agents/skills` 通用层已被 Kimi Code 扫描，Kimi 无需新增软链层。
+- **mcp-configuration**：Kimi Code 原生读取项目根 `.mcp.json`（源码与测试证实三层加载：`~/.kimi-code/mcp.json`、`<项目根>/.mcp.json`、`<cwd>/.kimi-code/mcp.json`，其中根目录 `.mcp.json` 即本 Skill 已生成的文件），无需第二份配置；仅需在客户端格式差异表新增 Kimi 列并补充 Kimi 消费方式说明，`.gitignore` 无需新增条目。
+- **rule-config**：项目类型有界扫描的 `PRUNE_DIRS` 常量与 SKILL.md find 块同步增加 `.kimi-code`；路由规则模板已含 "Claude/Kimi" 表述，保持不变。
+- **README 与文档**：全篇"三客户端"表述更新为四客户端，并补充 Kimi Code 支持说明。
+
+## Capabilities
+
+### New Capabilities
+- `kimi-code-support`: Kimi Code 客户端在 cadence-init 的 OpenSpec 产物、Superpowers 说明、MCP 配置与项目类型扫描中的支持行为。
+
+### Modified Capabilities
+- `init-skill-sequencing`: pre-check 的 OpenSpec 检查完成门槛、按客户端检测的增量补齐与 README 口径从 claude/codex/pi 三客户端扩为 claude/codex/pi/kimi 四客户端。
+
+## Impact
+
+- `cadence-init/skills/pre-check/SKILL.md`（步骤 5、no-interrupt 门槛、增量、快速参考、验证命令）与 `scripts/pre-check.sh`（职责边界注释）
+- `cadence-init/skills/mcp-configuration/SKILL.md`（`.kimi-code/mcp.json` 同步、格式差异表、.gitignore）
+- `cadence-init/skills/rule-config/SKILL.md` 与 `scripts/rule-config.py`（PRUNE_DIRS 有界扫描剪枝）
+- `README.md`（客户端表述与 skills 表格）
+- OpenSpec specs：`init-skill-sequencing`（修改）、`kimi-code-support`（新增）
+- 依赖：OpenSpec CLI 需支持 `--tools kimi`（1.8.0 已支持；实现时确认最低版本注记）

--- a/openspec/changes/support-kimi-code/proposal.md
+++ b/openspec/changes/support-kimi-code/proposal.md
@@ -20,7 +20,7 @@ Cadence 目前只对 Claude Code、Codex、pi 三客户端做环境初始化（O
 ## Impact
 
 - `cadence-init/skills/pre-check/SKILL.md`（步骤 5、no-interrupt 门槛、增量、快速参考、验证命令）与 `scripts/pre-check.sh`（职责边界注释）
-- `cadence-init/skills/mcp-configuration/SKILL.md`（`.kimi-code/mcp.json` 同步、格式差异表、.gitignore）
+- `cadence-init/skills/mcp-configuration/SKILL.md`（Kimi 消费方式说明、格式差异表 Kimi 列）
 - `cadence-init/skills/rule-config/SKILL.md` 与 `scripts/rule-config.py`（PRUNE_DIRS 有界扫描剪枝）
 - `README.md`（客户端表述与 skills 表格）
 - OpenSpec specs：`init-skill-sequencing`（修改）、`kimi-code-support`（新增）

--- a/openspec/changes/support-kimi-code/specs/init-skill-sequencing/spec.md
+++ b/openspec/changes/support-kimi-code/specs/init-skill-sequencing/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: OpenSpec 检查完成门槛不含 config.yaml
+
+pre-check 的 OpenSpec 检查完成条件 MUST 仅包含：OpenSpec CLI 可用，以及 claude/codex/pi/kimi 四客户端指令产物验证成功。pre-check MUST NOT 将 `openspec/config.yaml` 的存在性作为完成条件或失败条件。
+
+#### Scenario: 全新项目执行 pre-check
+
+- **WHEN** 在不存在 `openspec/config.yaml` 且无任何客户端指令产物的全新项目上执行 `/pre-check`
+- **THEN** pre-check 执行 `openspec init --tools claude,codex,pi,kimi` 生成四客户端产物后，OpenSpec 检查判定通过，不终止、不报失败
+
+#### Scenario: config.yaml 缺失但产物齐全
+
+- **WHEN** 四客户端指令产物齐全但 `openspec/config.yaml` 不存在
+- **THEN** OpenSpec 检查判定通过，并输出 config.yaml 将由 rule-config 创建的提示
+
+### Requirement: 按客户端检测的增量补齐
+
+pre-check MUST 分别检测 claude、codex、pi、kimi 四客户端指令产物的存在性；对缺失的客户端执行 `openspec init --tools <缺失客户端列表>`，随后执行 `openspec update`；产物已齐全的客户端 MUST NOT 被重新 init；`openspec/config.yaml` 的存在性 MUST NOT 作为分支判断条件。codex 客户端产物就绪判定 MUST 以项目根 `.agents/skills/` 下存在 `openspec-*` 目录为准（最新 OpenSpec 为 skills-only，codex 产物落项目根 `.agents/skills/`，不再产生 `.codex/` 目录）；MUST NOT 以 `.codex/skills/` 作为 codex 就绪判定路径。
+
+#### Scenario: rule-config 先行后执行 pre-check
+
+- **WHEN** 项目存在 rule-config 写入的 `openspec/config.yaml` 但四客户端指令产物均缺失，执行 `/pre-check`
+- **THEN** pre-check 执行 `openspec init --tools claude,codex,pi,kimi` 与 `openspec update`，四客户端产物验证通过，且 `openspec/config.yaml` 内容保持 rule-config 写入值不变
+
+#### Scenario: 仅 pi 产物缺失
+
+- **WHEN** claude、codex、kimi 产物齐全、pi 产物缺失，执行 `/pre-check`
+- **THEN** pre-check 仅执行 `openspec init --tools pi` 与 `openspec update`，claude、codex、kimi 产物不被重新生成
+
+#### Scenario: 三客户端产物齐全
+
+- **WHEN** claude、codex、pi 产物齐全、kimi 产物缺失，执行 `/pre-check`
+- **THEN** pre-check 仅执行 `openspec init --tools kimi` 与 `openspec update`，claude、codex、pi 产物不被重新生成
+
+#### Scenario: 四客户端产物齐全
+
+- **WHEN** claude、codex、pi、kimi 四客户端产物均齐全，执行 `/pre-check`
+- **THEN** pre-check 仅执行 `openspec update`，不执行任何 `openspec init`
+
+#### Scenario: codex 产物按最新路径判定
+
+- **WHEN** 项目经 `openspec init --tools codex` 生成产物（最新 OpenSpec 为 skills-only，产物在项目根 `.agents/skills/openspec-*`，无 `.codex/` 目录），执行 `/pre-check`
+- **THEN** pre-check 以 `.agents/skills/` 下存在 `openspec-*` 目录判定 codex 就绪，MUST NOT 因 `.codex/skills/` 不存在而误判 codex 缺失或重复执行 `openspec init --tools codex`
+
+### Requirement: 硬门槛与失败语义保留
+
+OpenSpec CLI 安装失败、`openspec init`/`openspec update` 失败、或四客户端指令产物验证失败时，no-interrupt 模式 MUST 立即终止 `/pre-check`，普通模式 MUST 报告失败；npx/uvx/ast-grep/codegraph/OpenSpec/Superpowers 六个基础检查的门槛地位 MUST 保持不变。
+
+#### Scenario: 产物验证失败
+
+- **WHEN** 以 `no-interrupt` 参数执行 `/pre-check`，init 与 update 执行后任一客户端指令产物验证失败
+- **THEN** `/pre-check` 立即终止，报告失败步骤、失败原因、已完成步骤和恢复建议，不宣称初始化成功
+
+### Requirement: README 职责边界同步
+
+README MUST 明确以下口径并与 pre-check SKILL.md 一致：pre-check 的 OpenSpec 检查范围为 OpenSpec CLI 与四客户端指令产物；`openspec/config.yaml` 由 rule-config 创建与合并；初始化顺序仍为 pre-check 先、rule-config 后，顺序颠倒时 pre-check 能按缺失客户端补齐产物。
+
+#### Scenario: 文档口径一致性核验
+
+- **WHEN** 对照阅读 README 初始化章节与 pre-check SKILL.md 的 OpenSpec 检查条款
+- **THEN** 两处对完成条件、config.yaml 归属与顺序约束的表述一致，无相互矛盾的验收口径

--- a/openspec/changes/support-kimi-code/specs/kimi-code-support/spec.md
+++ b/openspec/changes/support-kimi-code/specs/kimi-code-support/spec.md
@@ -1,0 +1,85 @@
+## Purpose
+
+定义 cadence-init 对 Kimi Code coding agent 的环境初始化、MCP 接入与项目类型扫描支持要求，使 Kimi Code 成为与 Claude Code、Codex、pi 并列的第四客户端。
+
+## ADDED Requirements
+
+### Requirement: OpenSpec 初始化包含 kimi 工具
+
+pre-check 对新项目的 OpenSpec 初始化 MUST 使用 `openspec init --tools claude,codex,pi,kimi`。对已存在 `openspec/config.yaml` 的项目，若 kimi 产物缺失，MUST 先执行 `openspec init --tools kimi`，再执行 `openspec update`；若 kimi 产物已存在，MUST 直接执行 `openspec update`。kimi 产物就绪判定为 `.kimi-code/skills/` 下存在 5 个 `openspec-*` 目录。pre-check MUST NOT 声称 `openspec update` 单独执行会为未选择过 kimi 工具的老项目新增 `.kimi-code/skills/openspec-*`。
+
+#### Scenario: 新项目初始化生成 kimi 产物
+
+- **WHEN** 项目不存在 `openspec/config.yaml` 且 pre-check 执行 OpenSpec 初始化
+- **THEN** 执行 `openspec init --tools claude,codex,pi,kimi`，且验证 `test -f .kimi-code/skills/openspec-propose/SKILL.md` 通过
+
+#### Scenario: 老项目缺少 kimi 产物时增量初始化
+
+- **WHEN** 项目已存在 `openspec/config.yaml` 但缺少 `.kimi-code/skills/openspec-*`
+- **THEN** pre-check 先执行 `openspec init --tools kimi`，确认生成 5 个 kimi skills，再执行 `openspec update`
+
+#### Scenario: 老项目已有 kimi 产物时更新
+
+- **WHEN** 项目已存在 `openspec/config.yaml` 且 `.kimi-code/skills/` 下 5 个 `openspec-*` 目录已存在
+- **THEN** pre-check 直接执行 `openspec update` 刷新已有工具产物
+
+### Requirement: Superpowers 说明 kimi 消费方式
+
+pre-check 的 Superpowers 四层软链 MUST 保持不变（`~/.agents/skills`、`~/.codex/skills/skills`、`~/.claude/skills`、`~/.pi/agent/skills`），MUST NOT 为 kimi 新增 `~/.kimi-code/skills` 软链层。文档 MUST 说明 Kimi Code 扫描用户级通用目录 `~/.agents/skills`，经该层获得 Superpowers skills，无需额外同步。
+
+#### Scenario: kimi 经通用层获得 Superpowers skills
+
+- **WHEN** 项目已按 pre-check 同步 `~/.agents/skills` 且 Kimi Code 在项目内启动
+- **THEN** 文档指明 Kimi 直接使用 `~/.agents/skills` 中的 Superpowers skills，无需额外同步层
+
+#### Scenario: 不新增 kimi 专属软链层
+
+- **WHEN** 读者查阅 pre-check 的 Superpowers 目录约定
+- **THEN** 文档不包含 `~/.kimi-code/skills` 作为软链同步目标
+
+### Requirement: MCP 配置说明 kimi 消费方式
+
+mcp-configuration MUST 说明 Kimi Code 原生读取项目根 `.mcp.json`（含 stdio/HTTP/SSE server），复用本 Skill 已生成的文件，MUST NOT 为 kimi 生成 `.kimi-code/mcp.json` 副本或在 `.gitignore` 中新增 kimi 专属条目。客户端格式差异表 MUST 覆盖 Kimi 列。
+
+#### Scenario: kimi 复用项目根 .mcp.json
+
+- **WHEN** 项目已按 mcp-configuration 生成 `.mcp.json` 且 Kimi Code 在项目内启动
+- **THEN** 文档指明 Kimi Code 原生读取该 `.mcp.json`（含 stdio 与 HTTP/SSE server），无需执行任何同步步骤
+
+#### Scenario: 不生成 kimi 专属 MCP 配置副本
+
+- **WHEN** 读者查阅 mcp-configuration 的检查清单与客户端格式差异表
+- **THEN** 文档不含生成 `.kimi-code/mcp.json` 的步骤，且格式差异表同时覆盖 Claude Code、Codex、pi、Kimi 四者
+
+#### Scenario: gitignore 不新增 kimi 条目
+
+- **WHEN** mcp-configuration 配置 `.gitignore`
+- **THEN** 不新增 `.kimi-code/mcp.json` 条目（`.mcp.json` 已在忽略清单内，Kimi 复用同一文件）
+
+### Requirement: 项目类型扫描剪枝 kimi 目录
+
+rule-config 的项目类型有界扫描 MUST 在脚本 `PRUNE_DIRS` 常量与 SKILL.md 中的 find 剪枝目录清单同步增加 `.kimi-code`，且二者逐项一致（受 harness 断言核对）。
+
+#### Scenario: 扫描剪枝 kimi 目录
+
+- **WHEN** rule-config 执行项目类型有界扫描且项目含 `.kimi-code/` 目录
+- **THEN** 该目录被剪枝，不参与源码扩展名检测
+
+#### Scenario: 剪枝清单一致性
+
+- **WHEN** 对照 rule-config SKILL.md 的 find 块与脚本 `PRUNE_DIRS` 常量
+- **THEN** 两者均包含 `.kimi-code` 且逐项一致
+
+### Requirement: README 与文档四客户端表述
+
+README MUST 以四客户端口径描述 pre-check 的 OpenSpec 检查范围（claude/codex/pi/kimi），与 pre-check SKILL.md 一致；MUST 在 skills 表格中更新 `/pre-check` 与 `/mcp-configuration` 的 Kimi 相关说明。
+
+#### Scenario: README 口径一致
+
+- **WHEN** 对照阅读 README 初始化章节与 pre-check SKILL.md 的 OpenSpec 检查条款
+- **THEN** 两处对客户端列表与 OpenSpec 检查范围的表述一致，均为四客户端
+
+#### Scenario: skills 表格更新
+
+- **WHEN** 查阅 README 的 skills 表格
+- **THEN** `/pre-check` 行包含 kimi 客户端产物说明，`/mcp-configuration` 行包含 `.kimi-code/mcp.json` 说明

--- a/openspec/changes/support-kimi-code/tasks.md
+++ b/openspec/changes/support-kimi-code/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: 支持 Kimi Code 第四客户端
+
+## 1. pre-check：OpenSpec 四客户端产物
+
+- [ ] 1.1 将 `cadence-init/skills/pre-check/SKILL.md` 步骤 5 的三客户端初始化命令更新为四客户端：新项目 `openspec init --tools claude,codex,pi,kimi`；按缺失客户端补齐的命令示例补充 `--tools kimi` 分支
+- [ ] 1.2 在步骤 5 的客户端就绪判定表新增 kimi 行：`.kimi-code/skills/` 下存在 5 个 `openspec-*` 目录即就绪
+- [ ] 1.3 更新步骤 5 的验证命令，新增 kimi 产物检查（`test -f .kimi-code/skills/openspec-propose/SKILL.md` 与 5 个目录计数）
+- [ ] 1.4 更新步骤 5 的产物结构说明：kimi 为 `.kimi-code/skills/openspec-*`，无 commands/adapter（与 OpenSpec CLI 实测一致）
+- [ ] 1.5 全篇"三客户端"表述改为"四客户端"（no-interrupt 强制完成策略表、检查流程图、快速参考表、判定规则、增量示例）
+- [ ] 1.6 查证 OpenSpec `--tools kimi` 的最低版本并在 SKILL.md 标注（与 pi ">= 1.4.1" 同款注记）；确认 `--tools pi` 注记一并保留
+- [ ] 1.7 更新 `scripts/pre-check.sh` 头部职责边界注释（OpenSpec 三客户端产物 → 四客户端），无逻辑改动
+
+## 2. pre-check：Superpowers 覆盖说明
+
+- [ ] 2.1 在步骤 6 Superpowers 的目录约定与说明中注明：`~/.agents/skills` 通用层已被 Kimi Code 扫描（用户级通用 skills），Kimi 无需额外同步层；不新增 `~/.kimi-code/skills` 软链目标
+
+## 3. mcp-configuration：Kimi 复用根目录 `.mcp.json`
+
+- [ ] 3.1 在 `cadence-init/skills/mcp-configuration/SKILL.md` 新增 Kimi 消费方式说明：Kimi Code 原生读取项目根 `.mcp.json`（源码与测试证实三层加载：`~/.kimi-code/mcp.json`、`<项目根>/.mcp.json`、`<cwd>/.kimi-code/mcp.json`），复用本 Skill 已生成的文件，无需第二份配置
+- [ ] 3.2 更新检查清单与处理流程：明确不为 Kimi 生成 `.kimi-code/mcp.json` 副本、不新增 `.gitignore` 条目；`directTools` 等未知字段被 Kimi 非严格 schema 静默剥离，无需专门处理
+- [ ] 3.3 更新客户端格式差异表，新增 Kimi 列（复用根目录 `.mcp.json`、JSON、stdio/HTTP/SSE 均支持）
+- [ ] 3.4 补充 Kimi 侧验证方式（`/mcp` 查看连接状态、`/mcp-config` 交互管理）与 API Key 安全提醒覆盖 Kimi
+
+## 4. rule-config：项目类型扫描剪枝
+
+- [ ] 4.1 在 `scripts/rule-config.py` 的 `PRUNE_DIRS` 常量增加 `.kimi-code`
+- [ ] 4.2 在 `cadence-init/skills/rule-config/SKILL.md` 的有界扫描 find 剪枝目录清单同步增加 `.kimi-code`
+- [ ] 4.3 运行 harness 断言 `assert_bounded_source_scan_contract` 确认两处清单逐项一致
+
+## 5. README 与文档
+
+- [ ] 5.1 `README.md` 全篇"三客户端"表述更新为四客户端（claude/codex/pi/kimi）
+- [ ] 5.2 更新 `README.md` skills 表格：`/pre-check` 行加入 kimi 客户端产物说明；`/mcp-configuration` 行加入 Kimi 原生读取根目录 `.mcp.json` 的说明
+- [ ] 5.3 在 `README.md` 增加 Kimi Code 支持说明（`.kimi-code/` 目录、MCP 原生复用 `.mcp.json`、Superpowers 经 `~/.agents/skills` 消费）
+
+## 6. 验证
+
+- [ ] 6.1 在临时项目执行 `openspec init --tools claude,codex,pi,kimi`，验证四客户端产物齐全（含 `.kimi-code/skills/` 5 个 openspec-*）
+- [ ] 6.2 运行 rule-config 测试套件（`tests/test_rule_config.py` 与生命周期脚本）确认 PRUNE_DIRS 变更无回归
+- [ ] 6.3 端到端冒烟：对临时项目按 pre-check → rule-config → mcp-configuration 顺序验证 kimi 产物、根目录 `.mcp.json` 被 Kimi 消费（无需第二份配置）


### PR DESCRIPTION
## 概述

为 cadence-init 三 skill（pre-check / mcp-configuration / rule-config）新增 **Kimi Code 第四客户端**支持，并附带修正 codex 客户端的 OpenSpec 产物就绪判定以适配最新 OpenSpec（skills-only）行为。

经两轮 reviewer 审查（整体审查 + 复审），全部发现项已解决，无遗留问题。

## 主要变更

### 1. pre-check：OpenSpec 四客户端产物
- OpenSpec 检查从三客户端（`claude,codex,pi`）扩为四客户端（`claude,codex,pi,kimi`）
- 新项目 `openspec init --tools claude,codex,pi,kimi`；按客户端增量补齐含 kimi
- kimi 就绪判定：`.kimi-code/skills/` 下 5 个 `openspec-*` 目录；验证命令、no-interrupt 门槛、流程图、快速参考同步更新
- Superpowers 四层软链不变，文档明确 `~/.agents/skills` 通用层已被 Kimi 扫描（Kimi 无需额外层）

### 2. pre-check：codex 判定适配最新 OpenSpec
- 最新 OpenSpec 为 skills-only，codex 产物落项目根 `.agents/skills/openspec-*`，不再产生 `.codex/`
- codex 就绪判定、目录结构说明、验证命令、产物概述文字（4 处）从 `.codex/skills/` 纠正为 `.agents/skills/`
- 用户级 Superpowers 软链 `~/.codex/skills/skills` 保持不动（项目级产物 vs 用户级软链严格区分）

### 3. mcp-configuration：Kimi 原生复用 `.mcp.json`
- Kimi Code 原生读取项目根 `.mcp.json`（源码三层加载：`~/.kimi-code/mcp.json` → `<项目根>/.mcp.json` → `<cwd>/.kimi-code/mcp.json`），复用本 Skill 已生成的文件，**无需第二份配置**
- 客户端格式差异表新增 Kimi 列（复用 `.mcp.json`、stdio/HTTP/SSE 均支持）
- `directTools` 等 pi 扩展字段对 Kimi 无害（非严格 schema 静默忽略）

### 4. rule-config：项目类型扫描剪枝 `.kimi-code`
- `PRUNE_DIRS` 常量与 SKILL.md find 块同步增加 `.kimi-code`（受 `assert_bounded_source_scan_contract` 双向断言）
- 路由规则模板已含 "Claude/Kimi" 表述，不改

### 5. README 与文档
- 全篇"三客户端"→"四客户端"表述
- skills 表格与 mcp-configuration 特性列表补充 Kimi 说明

## 关键设计决策
- **D1**：OpenSpec 无条件四客户端（始终 init，与现有三客户端策略一致）
- **D2**：Superpowers 不加第五层（Kimi 经 `~/.agents/skills` 通用层消费，避免双目录扫描冗余）
- **D3**：MCP 不生成 `.kimi-code/mcp.json` 副本（Kimi 原生读根目录 `.mcp.json`）
- **codex 路径**：以最新 OpenSpec 行为为准，不加版本条件（pre-check 始终装 latest）

## 验证
- ✅ `openspec init --tools claude,codex,pi,kimi` 四客户端产物齐全（kimi 5 skills，无 commands/adapter）
- ✅ 老项目增量 `init --tools kimi` + `update` 补齐
- ✅ rule-config unittest 160 OK；harness `sc-prune-dirs-contract` PASS（另有 5 个 L1 哈希失败为基线已存在，非本 change 引入）
- ✅ 最新 OpenSpec 实测：`.codex/` 不存在、codex 产物在 `.agents/skills/`、用户级软链不动
- ✅ reviewer 整体审查 + 复审：全部发现项已解决，无 Critical/Important 遗留

## OpenSpec 契约
- `openspec/changes/support-kimi-code/`：proposal / design / specs（新增 `kimi-code-support` + 修改 `init-skill-sequencing` delta）/ tasks
- `cadence/plans/2026-08-11_计划文档_实施_cadence支持kimi-code第四客户端_v1.0.md`：实施 Plan

## 改动范围
14 files changed, 828 insertions(+), 41 deletions(-)（含 OpenSpec change 规划产物与实施 Plan）

**不改动**：install-offline、.claude/rules、Superpowers 软链逻辑、.claude-plugin。