### PR TITLE
fix(rule-config): 模板定位 skill 自包含化——消除过期 marketplace 劫持

### DIFF
--- a/cadence-init/skills/rule-config/SKILL.md
+++ b/cadence-init/skills/rule-config/SKILL.md
@@ -41,7 +41,7 @@ disable-model-invocation: true
 
 ## 调用方式
 
-**第一步——定位脚本**：脚本是本 rule-config skill 的关联脚本，即本 SKILL 所在目录的 `scripts/rule-config.py`（各客户端按其 skill 安装位置定位该目录，如 `<skill 安装根>/cadence-init/skills/rule-config/`）。模板与脚本同包（skill 自包含），由脚本自动解析其 skill 目录下的 `references/`，Agent 不做模板定位。脚本只读，不要 `cd` 进 skill 目录，也不要把脚本复制到别处执行。若脚本报"skill 安装不完整"，重新安装 skill 后重试，不得从其他项目或安装位置复制模板补齐。
+**第一步——定位脚本**：脚本是本 rule-config skill 的关联脚本，即本 SKILL 所在目录的 `scripts/rule-config.py`，记为 `<RULE_CONFIG_PY>`（各客户端按其 skill 安装位置定位该目录，如 `<skill 安装根>/cadence-init/skills/rule-config/`）。模板与脚本同包（skill 自包含），由脚本自动解析其 skill 目录下的 `references/`，Agent 不做模板定位。脚本只读，不要 `cd` 进 skill 目录，也不要把脚本复制到别处执行。若脚本报"skill 安装不完整"，重新安装 skill 后重试，不得从其他项目或安装位置复制模板补齐。
 
 **第二步——确定报告与决策路径**：报告 `<REPORT>` 是临时中间产物，必须位于项目根之外。用 `mktemp` 在 `/tmp` 生成原子唯一路径（如 `mktemp -t rule-config-report.XXXXXX.json`），记住字面值，后续每条命令直接写出。决策文件 `<DECISIONS_JSON>` 为休眠兜底机制：当前无活跃冲突类型、计划不要求决策文件，仅在恢复逐条提问流程时才需生成（同样必须位于项目根之外）。脚本拒绝项目根内的 `--report` / `--decisions` 路径（退出码 2）。
 

--- a/cadence-init/skills/rule-config/SKILL.md
+++ b/cadence-init/skills/rule-config/SKILL.md
@@ -41,12 +41,7 @@ disable-model-invocation: true
 
 ## 调用方式
 
-**第一步——定位脚本（与 pre-check 同款约定）**：脚本是本 rule-config skill 的关联脚本。Agent 按以下候选根顺序定位并拼出完整绝对路径，记为 `<RULE_CONFIG_PY>`：
-
-1. plugin 缓存：`<plugin 缓存根>/cadence-init/skills/rule-config/scripts/rule-config.py`。
-2. 仓库安装根：`<skill 安装根>/cadence-init/skills/rule-config/scripts/rule-config.py`。
-
-若候选根下 `scripts/` 缺失，说明命中了不含关联脚本的旧版本缓存；重新安装或刷新 plugin 后重试，不得从其他项目目录复制脚本。脚本只读，不要 `cd` 进 skill 目录，也不要把脚本复制到别处执行。
+**第一步——定位脚本**：脚本是本 rule-config skill 的关联脚本，即本 SKILL 所在目录的 `scripts/rule-config.py`（各客户端按其 skill 安装位置定位该目录，如 `<skill 安装根>/cadence-init/skills/rule-config/`）。模板与脚本同包（skill 自包含），由脚本自动解析其 skill 目录下的 `references/`，Agent 不做模板定位。脚本只读，不要 `cd` 进 skill 目录，也不要把脚本复制到别处执行。若脚本报"skill 安装不完整"，重新安装 skill 后重试，不得从其他项目或安装位置复制模板补齐。
 
 **第二步——确定报告与决策路径**：报告 `<REPORT>` 是临时中间产物，必须位于项目根之外。用 `mktemp` 在 `/tmp` 生成原子唯一路径（如 `mktemp -t rule-config-report.XXXXXX.json`），记住字面值，后续每条命令直接写出。决策文件 `<DECISIONS_JSON>` 为休眠兜底机制：当前无活跃冲突类型、计划不要求决策文件，仅在恢复逐条提问流程时才需生成（同样必须位于项目根之外）。脚本拒绝项目根内的 `--report` / `--decisions` 路径（退出码 2）。
 

--- a/cadence-init/skills/rule-config/references/merge-semantics.md
+++ b/cadence-init/skills/rule-config/references/merge-semantics.md
@@ -289,17 +289,11 @@ L0 更新先完成 CLAUDE.md 与 AGENTS.md 的统一预检，收集本次全部�
 - 故障注入（design D6）：原子发布失败以目标目录 `chmod 555` 复现（`fx-readonly-target`）；备份失败以只读父目录复现（`fx-readonly-parent`）。
 - 对应测试：`ut-atomic_write-publish`、`ut-atomic_write-replace`、`ut-atomic_write-fail`、`it-s7-openspec-publish-failure-preserved`。
 
-### 11.5 模板三级定位
+### 11.5 模板定位（skill 自包含）
 
-模板根路径与 OpenSpec 配置模板路径必须**成对定位**并在后续步骤中复用（包括步骤 8 的 `code-reading.md`、步骤 10 的 `playwright.md` 和步骤 11 的 OpenSpec 配置）。
+模板根路径与 OpenSpec 配置模板路径 MUST 以脚本自身所在 skill 目录（`SKILL_DIR`，`Path(__file__).resolve().parent.parent`）为唯一来源：`SKILL_DIR/references/rules/` 与 `SKILL_DIR/references/openspec/config.yaml`。禁止引用 `~/.claude/plugins/` 等客户端目录候选或全局搜索回退；模板定位 MUST NOT 依赖 `HOME` 环境变量。
 
-按以下优先级顺序查找（S1b-01~04，SKILL 138-159 行）：
-
-1. **在线安装路径**：检查 `~/.claude/plugins/marketplaces/cadence-skills-marketplace/cadence-init/skills/rule-config/references/rules/` 下是否同时存在 `agent-routing-kernel.md`、`language.md`、`openspec-superpowers-workflow.md`，并检查同一 `references/` 下的 `openspec/config.yaml`。同时存在则取 `references/rules/` 为模板根路径、`references/openspec/config.yaml` 为 OpenSpec 配置模板路径。
-2. **离线安装路径**：检查 `~/.claude/plugins/marketplaces/cadence-skills-local/cadence-init/skills/rule-config/references/rules/` 下同样三件套与同 `references/` 下的 `openspec/config.yaml`。规则同上。
-3. **回退搜索（开发环境）**：使用 Glob 搜索标识文件 `**/cadence-init/skills/rule-config/references/rules/language.md`，从返回结果提取目录路径（去掉末尾 `language.md`）作为候选；回退路径需额外验证 `document-storage.md` 存在（即四件套：`agent-routing-kernel.md`、`language.md`、`openspec-superpowers-workflow.md`、`document-storage.md`），并验证同 `references/` 下 `openspec/config.yaml` 存在。多候选取修改时间最新者。
-
-**成对校验**：任一候选缺少 `references/openspec/config.yaml` 时不得选用该候选；所有候选均不完整时终止并报告缺失模板（对应测试 `ut-locate_templates-all-incomplete` / `it-s2-templates-missing`，非零退出、目标项目零写入）。
+**成对校验**：`references/rules/` 下必须存在 `agent-routing-kernel.md`、`language.md`、`openspec-superpowers-workflow.md`、`document-storage.md` 四件套，且 `references/openspec/config.yaml` 必须存在；缺任一即 `TemplateError` 失败关闭（非零退出、目标项目零写入），报告逐个列出缺失文件名并给出"skill 安装不完整，请重新安装"恢复建议（对应测试 `ut-locate_templates-incomplete`；空 HOME 正常运行为 `it-s2-skill-self-contained`）。
 
 ### 11.6 default_keep 语义（Task 8 裁决区分）
 
@@ -368,3 +362,5 @@ L0 更新先完成 CLAUDE.md 与 AGENTS.md 的统一预检，收集本次全部�
 `ut-s3-codegraph-section-unified-drift` / `ut-s3-codegraph-section-unified-merge` 覆盖（后者名称保留，断言已改为完整模板覆盖）。
 
 **2026-08-19 权威化对账（change rule-config-authoritative-overwrite）**：RF-05/L1-04~06/L0-03/L0-06/OS-03~05 普通模式列两模式统一为归档+权威处理；§11.6 A 类清单清空；it-s3-normal-keep-decision→it-s3-normal-authoritative-overwrite 等 7 个集成 ID 改名（清单见 skill-clause-map.md）；it-l0-drift-normal-keep-default、it-l1-drift-normal-keep-default、it-decisions-unknown、it-decisions-stale 四个用例随决策编排路径消亡移除。
+
+**2026-08-19 定位自包含化对账（change rule-config-self-contained-templates）**：模板三级定位（在线/离线/glob）删除，改为 skill 目录单源；it-s2-templates-missing 反转为 it-s2-skill-self-contained；TestLocateTemplates 六用例重写为 ut-locate_templates-skill-dir/-incomplete/-no-home/-ignore-stale-marketplace。

--- a/cadence-init/skills/rule-config/scripts/rule-config.py
+++ b/cadence-init/skills/rule-config/scripts/rule-config.py
@@ -232,10 +232,13 @@ MCPJSON_CODEGRAPH_ENTRY = {
 }
 
 
+# skill 自包含唯一定位基准：脚本自身所在 skill 目录（软链经 resolve 解析到真实仓库）。
+SKILL_DIR = Path(__file__).resolve().parent.parent
+
+
 def _load_reference(name: str) -> str:
     """从 skill 目录下的 references/<name> 加载文本（加载失败返回空串）。"""
-    skill_dir = Path(__file__).resolve().parent.parent
-    target = skill_dir / "references" / name
+    target = SKILL_DIR / "references" / name
     try:
         return target.read_text(encoding="utf-8")
     except OSError:
@@ -413,15 +416,13 @@ SOURCE_EXTS = (
     ".rb", ".swift", ".kt", ".c", ".cpp", ".cs",
 )
 
-# S2 locate_templates 成对校验所需文件清单（与 SKILL.md 步骤 1b 一致）。
-# 在线/离线固定路径校验三件套；glob 回退路径额外校验 document-storage.md。
+# S2 locate_templates 成对校验所需文件清单（rules/ 四件套，与 SKILL.md 步骤 1b 一致）。
 TEMPLATE_REQUIRED = (
     "agent-routing-kernel.md",
     "language.md",
     "openspec-superpowers-workflow.md",
+    "document-storage.md",
 )
-# glob 回退路径额外要求的文件（S1b-02）。
-TEMPLATE_REQUIRED_FALLBACK = ("document-storage.md",)
 
 # 全局 T0：main() 入口第一行记录（budget_seconds_excluding_codegraph 基准）。
 T0: float = time.monotonic()
@@ -1719,19 +1720,6 @@ def _detect_project_type(root: Path, intents: Intents) -> str:
     return detect_project(root, intents)["project_type"]
 
 
-# S2 locate_templates 固定路径的 rules 子目录后缀（相对 $HOME）。
-_ONLINE_RULES_SUBPATH = (
-    ".claude/plugins/marketplaces/cadence-skills-marketplace"
-    "/cadence-init/skills/rule-config/references/rules"
-)
-_OFFLINE_RULES_SUBPATH = (
-    ".claude/plugins/marketplaces/cadence-skills-local"
-    "/cadence-init/skills/rule-config/references/rules"
-)
-# glob 回退标识文件（相对任意搜索根）。
-_FALLBACK_GLOB_PATTERN = "**/cadence-init/skills/rule-config/references/rules/language.md"
-
-
 def detect_project(root: Path, intents: Intents) -> dict:
     """S1 项目类型检测（仅返回项目类型与检测证据）。
 
@@ -1782,133 +1770,28 @@ def _detect_main_config(root: Path) -> Optional[str]:
 
 
 def locate_templates() -> tuple:
-    """S2 三级模板定位（S1b-01~04）。
+    """模板定位：skill 自包含单源（契约「模板与脚本必须同源」）。
 
-    返回 (rules_root: Path, openspec_yaml: Path)。
-
-    固定路径之间按优先级短路（在线优先）：
-      1) 在线 ~/.claude/plugins/marketplaces/cadence-skills-marketplace/... 完整即直接返回；
-      2) 在线不完整 → 离线 ~/.claude/plugins/marketplaces/cadence-skills-local/... 完整即返回；
-      3) 固定路径均不完整 → glob 回退
-         **/cadence-init/skills/rule-config/references/rules/language.md
-         （多候选取 mtime 最新；mtime 比较仅在此阶段用于多候选择优）。
-
-    成对校验（S1b-02）：每候选 rules/ 下须含 TEMPLATE_REQUIRED 三件套
-    （回退路径额外须含 document-storage.md）+ 同级 references/openspec/config.yaml；
-    缺任则该候选不完整。固定路径间不混入统一 mtime 比较，以确保“在线优先”语义。
-    全部候选不完整 → TemplateError 终止并逐个列出每个候选具体缺失的文件名。
+    唯一候选：SKILL_DIR/references/（rules/ 四件套 + openspec/config.yaml）。
+    缺失任一 → TemplateError（列出缺失清单与重装建议）；不降级到任何外部路径。
     """
-    home = Path(os.path.expanduser("~"))
-    # (kind, rules_root, missing_files) 用于失败时构造详细错误
-    failures: list = []
-
-    # 1) 在线固定路径（短路优先：完整即返回，不查离线）
-    online_rules = home / _ONLINE_RULES_SUBPATH
-    online = _check_template_candidate(online_rules, fallback=False)
-    if online is not None:
-        return online[0], online[1]
-    failures.append((
-        "在线",
-        online_rules,
-        _missing_template_files(online_rules, fallback=False),
-    ))
-
-    # 2) 离线固定路径（在线不完整才查；完整即返回）
-    offline_rules = home / _OFFLINE_RULES_SUBPATH
-    offline = _check_template_candidate(offline_rules, fallback=False)
-    if offline is not None:
-        return offline[0], offline[1]
-    failures.append((
-        "离线",
-        offline_rules,
-        _missing_template_files(offline_rules, fallback=False),
-    ))
-
-    # 3) glob 回退：从 home 起搜索标识文件并成对校验；多候选取 mtime 最新
-    fallback_candidates: list = []  # (rules_root, openspec_yaml)
-    seen: set = set()
-    for lang_path in home.glob(_FALLBACK_GLOB_PATTERN):
-        rules_root = lang_path.parent
-        key = str(rules_root.resolve())
-        if key in seen:
-            continue
-        seen.add(key)
-        pair = _check_template_candidate(rules_root, fallback=True)
-        if pair is not None:
-            fallback_candidates.append(pair)
-        else:
-            failures.append((
-                "回退",
-                rules_root,
-                _missing_template_files(rules_root, fallback=True),
-            ))
-
-    if fallback_candidates:
-        # mtime 比较仅用于 glob 回退阶段的多候选择优
-        best = max(fallback_candidates, key=lambda c: _candidate_mtime(c[1]))
-        return best[0], best[1]
-
-    # 全不完整：构造逐候选缺失明细
-    raise TemplateError(_format_template_failures(failures))
-
-
-def _missing_template_files(rules_root: Path, *, fallback: bool) -> list:
-    """返回单一候选缺失的文件名列表（含同级 openspec/config.yaml）。"""
-    missing: list = []
-    required = list(TEMPLATE_REQUIRED)
-    if fallback:
-        required = required + list(TEMPLATE_REQUIRED_FALLBACK)
-    if not rules_root.is_dir():
-        # 目录不存在视为三件套（含回退的 document-storage.md）全缺
-        return list(required) + ["openspec/config.yaml"]
-    for name in required:
-        if not (rules_root / name).is_file():
-            missing.append(name)
-    openspec_yaml = rules_root.parent / "openspec" / "config.yaml"
+    references = SKILL_DIR / "references"
+    rules_root = references / "rules"
+    openspec_yaml = references / "openspec" / "config.yaml"
+    missing = [
+        f"references/rules/{name}"
+        for name in TEMPLATE_REQUIRED
+        if not (rules_root / name).is_file()
+    ]
     if not openspec_yaml.is_file():
-        missing.append("openspec/config.yaml")
-    return missing
-
-
-def _format_template_failures(failures: list) -> str:
-    """格式化全部不完整候选的缺失明细（每候选一行，列出缺失文件名）。"""
-    lines = ["模板定位失败：所有候选均不完整"]
-    for kind, rules_root, missing in failures:
-        if missing:
-            joined = "、".join(missing)
-            lines.append(f"{kind}候选 {rules_root} 缺 {joined}")
-        else:
-            lines.append(f"{kind}候选 {rules_root} 不完整")
-    lines.append("（在线/离线/回退均不完整）")
-    return "；".join(lines)
-
-
-def _check_template_candidate(rules_root: Path, *, fallback: bool):
-    """校验单一候选完整性。返回 (rules_root, openspec_yaml) 或 None。
-
-    在线/离线校验 TEMPLATE_REQUIRED 三件套；回退额外校验 document-storage.md。
-    所有候选还须存在同级 references/openspec/config.yaml。
-    """
-    if not rules_root.is_dir():
-        return None
-    required = list(TEMPLATE_REQUIRED)
-    if fallback:
-        required = required + list(TEMPLATE_REQUIRED_FALLBACK)
-    for name in required:
-        if not (rules_root / name).is_file():
-            return None
-    openspec_yaml = rules_root.parent / "openspec" / "config.yaml"
-    if not openspec_yaml.is_file():
-        return None
+        missing.append("references/openspec/config.yaml")
+    if missing:
+        raise TemplateError(
+            "skill 安装不完整（缺少模板文件）：\n  - "
+            + "\n  - ".join(missing)
+            + "\n请重新安装 skill 后重试。"
+        )
     return rules_root, openspec_yaml
-
-
-def _candidate_mtime(path: Path) -> float:
-    """安全读取文件 mtime（失败返回 0）。"""
-    try:
-        return path.stat().st_mtime
-    except OSError:
-        return 0.0
 
 
 def _iter_source_files(root: Path):
@@ -1925,8 +1808,7 @@ def _iter_source_files(root: Path):
 
 def _load_kernel_source() -> str:
     """加载 L0 kernel 规范源（references/rules/agent-routing-kernel.md）。"""
-    skill_dir = Path(__file__).resolve().parent.parent
-    kernel = skill_dir / "references" / "rules" / "agent-routing-kernel.md"
+    kernel = SKILL_DIR / "references" / "rules" / "agent-routing-kernel.md"
     try:
         return kernel.read_text(encoding="utf-8")
     except OSError:

--- a/cadence-init/skills/rule-config/scripts/rule-config.py
+++ b/cadence-init/skills/rule-config/scripts/rule-config.py
@@ -446,7 +446,7 @@ class BackupError(OSError):
 
 
 class TemplateError(OSError):
-    """模板定位失败（所有候选均不完整 → 终止并列缺失）。S2 locate_templates 用。"""
+    """模板定位失败（skill 目录必备模板缺失 → 终止并列缺失）。S2 locate_templates 用。"""
 
 
 # ---------------------------------------------------------------------------
@@ -1397,7 +1397,7 @@ def compute_plan(root: Path, intents: Intents) -> dict:
     s1["elapsed_ms"] = int((time.monotonic() - t_s1) * 1000)  # codex 终审 I4：真实计时
     plan["steps"][STEP_DETECT] = s1
 
-    # --- S2 locate templates：三级定位 ---
+    # --- S2 locate templates：skill 自包含单源定位 ---
     s2 = _step_skeleton(STEP_TEMPLATES)
     t_s2 = time.monotonic()  # codex 终审 I4：S1-S7 真实计时（起点）
     try:
@@ -3308,7 +3308,7 @@ def run_dry_run(root: Path, intents: Intents, report: dict) -> int:
     """dry-run：compute_plan + 只读预演入口 warnings + 写报告，零写入。"""
     plan = compute_plan(root, intents)
     _sync_plan_to_report(plan, report, intents)
-    # S2 模板定位失败（§11.5：所有候选不完整 → 终止并报告，非零退出）
+    # S2 模板定位失败（§11.5：skill 目录模板不完整 → 终止并报告，非零退出）
     if plan.get("failure"):
         report["overall"] = "fail"
         report["failure"] = {

--- a/cadence-init/skills/rule-config/scripts/rule-config.py
+++ b/cadence-init/skills/rule-config/scripts/rule-config.py
@@ -1421,7 +1421,7 @@ def compute_plan(root: Path, intents: Intents) -> dict:
         plan["failure"] = {
             "step": STEP_TEMPLATES,
             "reason": str(exc),
-            "recovery": "检查模板安装路径或提供完整模板候选",
+            "recovery": "确认 skill 安装完整（references 必备文件齐全），必要时重新安装 skill",
         }
     s2["elapsed_ms"] = int((time.monotonic() - t_s2) * 1000)  # codex 终审 I4：真实计时
     plan["steps"][STEP_TEMPLATES] = s2

--- a/cadence-init/skills/rule-config/tests/skill-clause-map.md
+++ b/cadence-init/skills/rule-config/tests/skill-clause-map.md
@@ -5,6 +5,7 @@
 > 行号基准：SKILL 行号区间基于瘦身前 758 行版本（行号对账基准），新 SKILL.md 已瘦身为编排骨架，语义正文见 references/merge-semantics.md。
 > 用途：Task 2/3 的用例清单来源；Task 10 语义迁移矩阵正文来源。本文档作为测试文件提交，后续任何脚本行为变更必须先与本文档对账。
 > 2026-08-19 对账（change rule-config-authoritative-overwrite）：六类受管冲突转两模式确定性动作；7 个集成 ID 改名，4 个用例移除，新增 ut-validate-decisions-dormant 休眠单测 4 例；SKILL 行号区间不变（语义正文在 references/merge-semantics.md）。
+> 2026-08-19 变更记录（change rule-config-self-contained-templates）：S1b-01~04 由模板三级定位（在线/离线/glob 回退）对账为 skill 目录单源自包含定位（references/merge-semantics.md §11.5 同步重写）；旧用例 ut-locate_templates-online/-offline/-fallback/-pair-check/-mtime-latest/-all-incomplete 与 it-s2-templates-missing 移除，新增 ut-locate_templates-skill-dir/-incomplete/-no-home/-ignore-stale-marketplace 与 it-s2-skill-self-contained；fx-templates-* fixture 删除（改为测试内 inline 构造）；S1b 行号区间改指瘦身版 SKILL「调用方式·第一步」（42-44 行）。
 
 ## 0. 命名与列定义
 
@@ -137,10 +138,10 @@
 | 131/133-135 | S1a-03 有输出或存在主工程配置→Coding；全无→非 Coding；检测结果记入报告 | 两模式 | detect_project | fx-noncoding-project | ut-detect_project-main-config | 仅含 `package.json`/`pyproject.toml` 等主配置即判 Coding；报告记录检测证据 |
 | 136 | S1a-04 项目类型按两模式唯⼀规则确定（`--project-type`：普通模式仅提升 non-coding→coding；no-interrupt 完全忽略；codex 五轮重构，原「用户指定优先」与 s1 冲突已删） | 两模式 | detect_project / compute_plan | fx-noncoding-project / fx-coding-project | ut-detect_project-ignores-cli / ut-final-project-type-* / it-s1-normal-cli-promotes / it-s1-no-interrupt-ignores-cli | 检测结果 + CLI 按两模式规则计算 final `project_type`；detect 不读取 CLI |
 | 133 | S1a-05 无人工交互模式下不等待用户确认 | no-interrupt | detect_project | fx-empty-project | it-s1-no-confirm | no-interrupt 下检测直接落报告，无提问冲突项 |
-| 138-157 | S1b-01 模板目录三级定位：在线安装路径→离线安装路径→开发回退 Glob | 两模式 | locate_templates | fx-templates-online / fx-templates-offline / fx-templates-dev | ut-locate_templates-online / ut-locate_templates-offline / ut-locate_templates-fallback | 各级候选按优先级命中并返回成对路径 |
-| 143/147/156/159 | S1b-02 每候选成对校验 rules 三件套（回退另需 document-storage.md）+ 同级 `references/openspec/config.yaml`；缺 config.yaml 不得选用 | 两模式 | locate_templates | fx-templates-incomplete | ut-locate_templates-pair-check | 缺任一成对文件的候选被跳过 |
-| 157 | S1b-03 回退路径多候选取修改时间最新者 | 两模式 | locate_templates | fx-templates-multi | ut-locate_templates-mtime-latest | 返回 mtime 最新的通过验证候选 |
-| 159 | S1b-04 全部候选不完整时终止并报告缺失模板 | 两模式 | locate_templates | fx-templates-all-incomplete | ut-locate_templates-all-incomplete / it-s2-templates-missing | 非零退出；报告列出各候选缺失项；目标项目零写入 |
+| 42-44 | S1b-01 模板单源定位：脚本以自身 skill 目录（`SKILL_DIR`，`Path(__file__).resolve().parent.parent`）为唯一模板源（`SKILL_DIR/references/rules/` + `SKILL_DIR/references/openspec/config.yaml`）；无客户端目录候选、无全局搜索回退 | 两模式 | locate_templates | —（测试内 inline 构造完整 skill 目录） | ut-locate_templates-skill-dir | 返回 skill 目录下成对路径（rules 根 + openspec config.yaml） |
+| 42-44 | S1b-02 成对校验 rules 四件套（agent-routing-kernel/language/openspec-superpowers-workflow/document-storage）+ 同级 `references/openspec/config.yaml`；缺任一即 `TemplateError` 失败关闭 | 两模式 | locate_templates | —（测试内 inline 缺件构造） | ut-locate_templates-incomplete | 非零退出；错误消息逐个列出缺失文件名并含"重新安装"恢复建议；目标项目零写入 |
+| 42-44 | S1b-03 模板定位不依赖 `HOME` 环境变量 | 两模式 | locate_templates | —（测试内 inline 空 HOME） | ut-locate_templates-no-home / it-s2-skill-self-contained | 空 HOME 下仍命中 skill 目录模板并正常运行 |
+| 42-44 | S1b-04 过期 marketplace 副本存在亦被忽略（naruto 事故回归） | 两模式 | locate_templates | —（测试内 inline 过期副本） | ut-locate_templates-ignore-stale-marketplace | 过期 marketplace 副本内容不同，仍取 skill 目录模板 |
 | 161-165 | S1c-01 创建 `.claude/rules`（幂等） | 两模式 | step_rules_files | fx-empty-project | it-s3-mkdir-idempotent | 重复运行不报错、目录权限不变 |
 | 171-181 | S1d-01 `.claude/rules/` 框架受管清单为 7 个：mcp-servers/code-reading/document-storage/language/markdown-format/code-usage/playwright；Playwright 按启用/已存在条件进入处理，L1 独立于此清单 | 两模式 | step_rules_files | fx-empty-project | ut-s3-authoritative-overwrite / ut-s3-authoritative-idempotent | 受管落地名不含 agent-routing-kernel；存在 drift 时权威覆盖，内容一致时幂等跳过 |
 | 179-180 | S1d-02 `code-usage-coding.md`/`code-usage-noncoding.md` 按最终项目类型单选来源，始终写入 `.claude/rules/code-usage.md`；历史双文件归档后移除 | 两模式 | step_rules_files | fx-coding-project / fx-noncoding-project | TestCodeUsageSingleSource / test_coding_project_gets_code_usage_md / test_noncoding_project_gets_noncoding_source_at_fixed_name / test_code_usage_asset_records_selected_template_source | Coding 内容=coding 模板；非 Coding 内容=noncoding 模板；plan 的 `template_source` 与项目类型一致；双来源文件不落地 |

--- a/cadence-init/skills/rule-config/tests/test_rule_config.py
+++ b/cadence-init/skills/rule-config/tests/test_rule_config.py
@@ -1076,169 +1076,83 @@ class TestDetectProject(unittest.TestCase):
 
 
 class TestLocateTemplates(unittest.TestCase):
+    """ut-locate_templates-* / skill 自包含单源定位契约（S1b 重构）。"""
+
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
-        self.home = Path(self.tmp.name) / "fakehome"
-        self.home.mkdir()
-        # 记录原始 HOME，用 addCleanup 恢复
-        self._orig_home = os.environ.get("HOME")
-        os.environ["HOME"] = str(self.home)
-        self.addCleanup(self._restore_home)
+        self.root = Path(self.tmp.name)
 
-    def _restore_home(self):
-        if self._orig_home is None:
-            os.environ.pop("HOME", None)
-        else:
-            os.environ["HOME"] = self._orig_home
+    def _make_skill_dir(self, missing=()):
+        """构造完整 skill 目录 fixture：<root>/skill/，可按 missing 缺件。"""
+        skill = self.root / "skill"
+        rules = skill / "references" / "rules"
+        rules.mkdir(parents=True)
+        for name in ("agent-routing-kernel.md", "language.md",
+                     "openspec-superpowers-workflow.md", "document-storage.md"):
+            if name not in missing:
+                (rules / name).write_text(f"tpl:{name}\n", encoding="utf-8")
+        (skill / "references" / "openspec").mkdir(parents=True)
+        if "config.yaml" not in missing:
+            (skill / "references" / "openspec" / "config.yaml").write_text(
+                "schema: spec-driven\n", encoding="utf-8"
+            )
+        return skill
 
-    # --- ut-locate_templates-online / S1b-01（在线路径优先命中）---
-    def test_online_path_preferred(self):
-        """ut-locate_templates-online / S1b-01（在线 marketplace 路径完整时优先返回）"""
-        online = (
-            self.home / ".claude" / "plugins" / "marketplaces" / "cadence-skills-marketplace"
-            / "cadence-init" / "skills" / "rule-config" / "references" / "rules"
+    def test_skill_dir_templates_preferred(self):
+        """ut-locate_templates-skill-dir / S1b-01（skill 目录完整 → 以其 references 为唯一模板源）"""
+        skill = self._make_skill_dir()
+        with mock.patch.object(rc, "SKILL_DIR", skill):
+            rules_root, openspec_yaml = rc.locate_templates()
+        self.assertEqual(rules_root, skill / "references" / "rules")
+        self.assertEqual(
+            openspec_yaml, skill / "references" / "openspec" / "config.yaml"
         )
-        _write_minimal_templates(online)
-        rules_root, openspec_yaml = rc.locate_templates()
-        self.assertEqual(rules_root, online)
-        self.assertTrue(openspec_yaml.exists())
-        self.assertEqual(openspec_yaml.name, "config.yaml")
 
-    # --- ut-locate_templates-offline / S1b-01（离线路径命中）---
-    def test_offline_path_used_when_online_missing(self):
-        """ut-locate_templates-offline / S1b-01（在线缺失时回退到离线 cadence-skills-local）"""
-        offline = (
-            self.home / ".claude" / "plugins" / "marketplaces" / "cadence-skills-local"
-            / "cadence-init" / "skills" / "rule-config" / "references" / "rules"
-        )
-        _write_minimal_templates(offline)
-        rules_root, _ = rc.locate_templates()
-        self.assertEqual(rules_root, offline)
-
-    # --- ut-locate_templates-fallback / S1b-01（glob 回退；需 document-storage.md）---
-    def test_glob_fallback_when_fixed_paths_missing(self):
-        """ut-locate_templates-fallback / S1b-01（固定路径均缺失时 glob 回退；候选需含 document-storage.md）"""
-        # 在 fakehome 下构造一个 glob 可命中的候选（带 document-storage.md）
-        dev_candidate = (
-            self.home / "workspace" / "proj" / "cadence-init" / "skills"
-            / "rule-config" / "references" / "rules"
-        )
-        _write_minimal_templates(dev_candidate, fallback=True)
-        rules_root, _ = rc.locate_templates()
-        self.assertEqual(rules_root, dev_candidate)
-
-    # --- ut-locate_templates-pair-check / S1b-02（缺成对文件或 config.yaml 的候选被跳过）---
-    def test_incomplete_candidate_skipped(self):
-        """ut-locate_templates-pair-check / S1b-02（在线候选缺 config.yaml → 跳过；落到 glob 回退完整候选）"""
-        # 在线候选缺 config.yaml（不写 openspec/config.yaml）
-        online_rules = (
-            self.home / ".claude" / "plugins" / "marketplaces" / "cadence-skills-marketplace"
-            / "cadence-init" / "skills" / "rule-config" / "references" / "rules"
-        )
-        online_rules.mkdir(parents=True)
-        for name in _ONLINE_RULES:
-            (online_rules / name).write_text("# x\n")
-        # 故意不写 openspec/config.yaml → 该候选不完整
-        # glob 回退候选完整（带 document-storage.md + config.yaml）
-        dev_candidate = (
-            self.home / "workspace" / "proj" / "cadence-init" / "skills"
-            / "rule-config" / "references" / "rules"
-        )
-        _write_minimal_templates(dev_candidate, fallback=True)
-        rules_root, _ = rc.locate_templates()
-        self.assertEqual(rules_root, dev_candidate)
-
-    # --- ut-locate_templates-mtime-latest / S1b-03（多候选取 mtime 最新）---
-    def test_multiple_candidates_pick_latest_mtime(self):
-        """ut-locate_templates-mtime-latest / S1b-03（glob 多候选通过校验后取修改时间最新者）"""
-        old_candidate = (
-            self.home / "workspace" / "old" / "cadence-init" / "skills"
-            / "rule-config" / "references" / "rules"
-        )
-        new_candidate = (
-            self.home / "workspace" / "new" / "cadence-init" / "skills"
-            / "rule-config" / "references" / "rules"
-        )
-        _write_minimal_templates(old_candidate, fallback=True)
-        _write_minimal_templates(new_candidate, fallback=True)
-        # 确保老候选的 openspec_yaml（mtime 比较基准）严格更新
-        import time as _time
-        _time.sleep(0.05)
-        (old_candidate.parent / "openspec" / "config.yaml").touch()
-        # 断言：mtime 主导 → 老候选胜出
-        rules_root, _ = rc.locate_templates()
-        self.assertEqual(rules_root, old_candidate)
-
-    # --- ut-locate_templates-online-preferred-over-offline / S1b-01（双有效场景在线优先）---
-    def test_online_preferred_over_offline_when_both_valid(self):
-        """ut-locate_templates-online-preferred / S1b-01（在线与离线均完整且离线 mtime 更新时仍返回在线）"""
-        online = (
-            self.home / ".claude" / "plugins" / "marketplaces" / "cadence-skills-marketplace"
-            / "cadence-init" / "skills" / "rule-config" / "references" / "rules"
-        )
-        offline = (
-            self.home / ".claude" / "plugins" / "marketplaces" / "cadence-skills-local"
-            / "cadence-init" / "skills" / "rule-config" / "references" / "rules"
-        )
-        _write_minimal_templates(online)
-        _write_minimal_templates(offline)
-        # 让离线 mtime 严格更新，确保“在线优先”是短路优先级而非 mtime 选择
-        import time as _time
-        _time.sleep(0.05)
-        (offline / "language.md").touch()
-        rules_root, _ = rc.locate_templates()
-        self.assertEqual(rules_root, online)
-
-    # --- ut-locate_templates-error-lists-missing / S1b-04（TemplateError 列出每个候选缺失文件名）---
-    def test_template_error_lists_missing_files(self):
-        """ut-locate_templates-error-lists-missing / S1b-04（全不完整时 TemplateError 消息列出缺失文件名）"""
-        # 在线候选：目录存在但缺 openspec/config.yaml（三件套齐全）
-        online_rules = (
-            self.home / ".claude" / "plugins" / "marketplaces" / "cadence-skills-marketplace"
-            / "cadence-init" / "skills" / "rule-config" / "references" / "rules"
-        )
-        online_rules.mkdir(parents=True)
-        for name in _ONLINE_RULES:
-            (online_rules / name).write_text("# x\n", encoding="utf-8")
-        # 离线候选：目录存在但缺 language.md
-        offline_rules = (
-            self.home / ".claude" / "plugins" / "marketplaces" / "cadence-skills-local"
-            / "cadence-init" / "skills" / "rule-config" / "references" / "rules"
-        )
-        offline_rules.mkdir(parents=True)
-        for name in (_ONLINE_RULES[0], _ONLINE_RULES[2]):  # 仅写 ark + osw，缺 language.md
-            (offline_rules / name).write_text("# x\n", encoding="utf-8")
-        # glob 回退候选：目录存在但缺 document-storage.md（fallback 额外要求）
-        dev_rules = (
-            self.home / "workspace" / "proj" / "cadence-init" / "skills"
-            / "rule-config" / "references" / "rules"
-        )
-        dev_rules.mkdir(parents=True)
-        for name in _ONLINE_RULES:
-            (dev_rules / name).write_text("# x\n", encoding="utf-8")
-        # 故意不写 document-storage.md，并补上 config.yaml 让 language.md 作为 glob 标识可命中
-        openspec_dir = dev_rules.parent / "openspec"
-        openspec_dir.mkdir(parents=True, exist_ok=True)
-        (openspec_dir / "config.yaml").write_text("schema: spec-driven\n", encoding="utf-8")
-        with self.assertRaises(rc.TemplateError) as ctx:
-            rc.locate_templates()
+    def test_missing_files_raise_template_error_with_list(self):
+        """ut-locate_templates-incomplete / S1b-02（缺件 → TemplateError 且列出缺失清单与重装建议）"""
+        skill = self._make_skill_dir(missing=("document-storage.md", "config.yaml"))
+        with mock.patch.object(rc, "SKILL_DIR", skill):
+            with self.assertRaises(rc.TemplateError) as ctx:
+                rc.locate_templates()
         msg = str(ctx.exception)
-        # 断言消息含每个候选具体缺失的文件名
-        self.assertIn("openspec/config.yaml", msg)  # 在线候选缺
-        self.assertIn("language.md", msg)  # 离线候选缺
-        self.assertIn("document-storage.md", msg)  # 回退候选缺
-        self.assertIn("在线候选", msg)
-        self.assertIn("离线候选", msg)
-        self.assertIn("回退候选", msg)
+        self.assertIn("document-storage.md", msg)
+        self.assertIn("config.yaml", msg)
+        self.assertIn("重新安装", msg)
 
-    # --- ut-locate_templates-all-incomplete / S1b-04（全不完整 → TemplateError）---
-    def test_all_incomplete_raises_template_error(self):
-        """ut-locate_templates-all-incomplete / S1b-04（所有候选均不完整 → TemplateError 终止）"""
-        # 不创建任何模板候选；HOME 下无任何 cadence-init/skills/rule-config 路径
-        # glob 也无命中 → TemplateError
-        with self.assertRaises(rc.TemplateError):
-            rc.locate_templates()
+    def test_no_home_dependency(self):
+        """ut-locate_templates-no-home / S1b-03（HOME 为空目录仍命中 skill 目录）"""
+        skill = self._make_skill_dir()
+        empty_home = self.root / "empty-home"
+        empty_home.mkdir()
+        with mock.patch.object(rc, "SKILL_DIR", skill), \
+                mock.patch.dict(os.environ, {"HOME": str(empty_home)}):
+            rules_root, _ = rc.locate_templates()
+        self.assertEqual(rules_root, skill / "references" / "rules")
+
+    def test_stale_marketplace_copy_ignored(self):
+        """ut-locate_templates-ignore-stale-marketplace / 回归（naruto 事故场景）：
+        过期 marketplace 副本存在且内容不同，仍取 skill 目录模板。"""
+        skill = self._make_skill_dir()
+        stale_home = self.root / "home"
+        mkt_rules = (
+            stale_home / ".claude" / "plugins" / "marketplaces"
+            / "cadence-skills-marketplace" / "cadence-init" / "skills"
+            / "rule-config" / "references" / "rules"
+        )
+        mkt_rules.mkdir(parents=True)
+        for name in ("agent-routing-kernel.md", "language.md",
+                     "openspec-superpowers-workflow.md", "document-storage.md"):
+            (mkt_rules / name).write_text("旧模板内容\n", encoding="utf-8")
+        (mkt_rules.parent.parent / "openspec").mkdir(parents=True)
+        (mkt_rules.parent.parent / "openspec" / "config.yaml").write_text(
+            "schema: spec-driven\n", encoding="utf-8"
+        )
+        with mock.patch.object(rc, "SKILL_DIR", skill), \
+                mock.patch.dict(os.environ, {"HOME": str(stale_home)}):
+            rules_root, _ = rc.locate_templates()
+        self.assertEqual(rules_root, skill / "references" / "rules")
+        self.assertNotEqual(str(rules_root), str(mkt_rules))
 
 
 # ---------------------------------------------------------------------------

--- a/cadence-init/skills/rule-config/tests/test_rule_config.py
+++ b/cadence-init/skills/rule-config/tests/test_rule_config.py
@@ -735,25 +735,6 @@ class TestClassifyL1(unittest.TestCase):
 # 加载方式与 Task 4 一致；测试自建临时 fixture，不依赖仓库实际环境。
 # ---------------------------------------------------------------------------
 
-# locate_templates 成对校验所需的最小文件集（在线/离线路径三件套 + config.yaml）
-_ONLINE_RULES = ("agent-routing-kernel.md", "language.md", "openspec-superpowers-workflow.md")
-# 回退 glob 路径额外需要 document-storage.md（S1b-02）
-_FALLBACK_EXTRA = ("document-storage.md",)
-
-
-def _write_minimal_templates(rules_dir: Path, *, fallback: bool = False) -> None:
-    """在 rules_dir 下创建成对校验所需的最小模板占位文件 + 同级 openspec/config.yaml。"""
-    rules_dir.mkdir(parents=True, exist_ok=True)
-    for name in _ONLINE_RULES:
-        (rules_dir / name).write_text(f"# placeholder {name}\n", encoding="utf-8")
-    if fallback:
-        for name in _FALLBACK_EXTRA:
-            (rules_dir / name).write_text(f"# placeholder {name}\n", encoding="utf-8")
-    openspec_dir = rules_dir.parent / "openspec"
-    openspec_dir.mkdir(parents=True, exist_ok=True)
-    (openspec_dir / "config.yaml").write_text("schema: spec-driven\n", encoding="utf-8")
-
-
 def _intents(**overrides):
     """构造 rc.Intents，默认空意图。"""
     defaults = dict(

--- a/cadence-init/skills/rule-config/tests/verify-managed-lifecycle.sh
+++ b/cadence-init/skills/rule-config/tests/verify-managed-lifecycle.sh
@@ -103,6 +103,8 @@ trap 'rm -rf "$TEST_ROOT"' EXIT HUP INT TERM
 # 的 references 复制到临时 HOME 的该优先路径，避免读取开发机插件缓存造成 fixture 与
 # 运行时模板版本不一致。仅隔离环境，不改变任何生产模板定位优先级或断言语义。
 TEST_HOME="$TEST_ROOT/home"
+# NOTE(2026-08-19 Task 1 裁决)：marketplace fixture 三行在红态仍需保留——旧实现 glob 回退
+# 仅在 $HOME 下搜索，删 fixture 会连带打红整个套件；删除移交 Task 2（实现合流后）。
 ONLINE_TEMPLATE_SKILL="$TEST_HOME/.claude/plugins/marketplaces/cadence-skills-marketplace/cadence-init/skills/rule-config"
 mkdir -p "$ONLINE_TEMPLATE_SKILL" || exit 1
 cp -R "$TEST_DIR/../references" "$ONLINE_TEMPLATE_SKILL/references" || exit 1
@@ -1468,25 +1470,24 @@ else
   record_result it-apply-failure-report-fields "$RUN_STATUS" present missing fail
 fi
 
-# C16e. 模板全缺 → fail closed 非零退出、目标项目零写入（it-s2-templates-missing / §11.5 S1b-04）。
-# HOME 换为空目录使在线/离线/glob 回退候选全部不完整。
+# C16e. 空 HOME 仍可运行——模板来自 skill 目录，不依赖 HOME（it-s2-skill-self-contained / §11.5）。
+# 2026-08-19 语义反转：旧契约为「候选全缺 → 失败关闭」；新契约（skill 自包含）下 HOME 无关。
+# NOTE：ONLINE_TEMPLATE_SKILL fixture 删除待 Task 2（红态删除会连带打红全套件，见 Task 1 报告）。
 case_root="$TEST_ROOT/fx-templates-missing"
 mkdir -p "$case_root"
 printf '# placeholder\n' > "$case_root/README.md"
 fake_home="$TEST_ROOT/fake-home-empty"
 mkdir -p "$fake_home"
-before=$(tree_hash "$case_root")
 REPORT="$(mktemp /tmp/rule-config-report.XXXXXX)"
 set +e
 HOME="$fake_home" "$(command -v python3)" "$SCRIPT" apply --project-root "$case_root" --report "$REPORT" --no-interrupt >/dev/null 2>&1
 RUN_STATUS=$?
 set -e
-after=$(tree_hash "$case_root")
-if [ "$RUN_STATUS" -ne 0 ] && [ "$before" = "$after" ] \
-  && jqr "['overall']" 2>/dev/null | grep -qix 'fail'; then
-  record_result it-s2-templates-missing "$RUN_STATUS" "$before" "$after" pass
+if [ "$RUN_STATUS" -eq 0 ] \
+  && ! jqr "['overall']" 2>/dev/null | grep -qix 'fail'; then
+  record_result it-s2-skill-self-contained "$RUN_STATUS" "-" "-" pass
 else
-  record_result it-s2-templates-missing "$RUN_STATUS" "$before" "$after" fail
+  record_result it-s2-skill-self-contained "$RUN_STATUS" "-" "-" fail
 fi
 
 # C16f. 空项目创建全套（it-s3-create / NC-01；it-s3-rules-create / RF-01；

--- a/cadence-init/skills/rule-config/tests/verify-managed-lifecycle.sh
+++ b/cadence-init/skills/rule-config/tests/verify-managed-lifecycle.sh
@@ -99,15 +99,10 @@ done
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT HUP INT TERM
 
-# 测试隔离：脚本的 S2 契约要求优先读取 $HOME 下的在线 plugin 模板。将本 worktree
-# 的 references 复制到临时 HOME 的该优先路径，避免读取开发机插件缓存造成 fixture 与
-# 运行时模板版本不一致。仅隔离环境，不改变任何生产模板定位优先级或断言语义。
+# 测试隔离：模板定位已改为 skill 自包含单源（不读取 $HOME 下任何路径）。仍将会话
+# HOME 指向临时目录，避免脚本或子进程触碰开发机真实 HOME；仅隔离环境，不改变断言语义。
 TEST_HOME="$TEST_ROOT/home"
-# NOTE(2026-08-19 Task 1 裁决)：marketplace fixture 三行在红态仍需保留——旧实现 glob 回退
-# 仅在 $HOME 下搜索，删 fixture 会连带打红整个套件；删除移交 Task 2（实现合流后）。
-ONLINE_TEMPLATE_SKILL="$TEST_HOME/.claude/plugins/marketplaces/cadence-skills-marketplace/cadence-init/skills/rule-config"
-mkdir -p "$ONLINE_TEMPLATE_SKILL" || exit 1
-cp -R "$TEST_DIR/../references" "$ONLINE_TEMPLATE_SKILL/references" || exit 1
+mkdir -p "$TEST_HOME" || exit 1
 export HOME="$TEST_HOME"
 
 PASS_COUNT=0
@@ -1472,7 +1467,6 @@ fi
 
 # C16e. 空 HOME 仍可运行——模板来自 skill 目录，不依赖 HOME（it-s2-skill-self-contained / §11.5）。
 # 2026-08-19 语义反转：旧契约为「候选全缺 → 失败关闭」；新契约（skill 自包含）下 HOME 无关。
-# NOTE：ONLINE_TEMPLATE_SKILL fixture 删除待 Task 2（红态删除会连带打红全套件，见 Task 1 报告）。
 case_root="$TEST_ROOT/fx-templates-missing"
 mkdir -p "$case_root"
 printf '# placeholder\n' > "$case_root/README.md"

--- a/cadence/plans/2026-08-19_计划文档_实施_rule-config模板定位skill自包含化_v1.0.md
+++ b/cadence/plans/2026-08-19_计划文档_实施_rule-config模板定位skill自包含化_v1.0.md
@@ -1,0 +1,341 @@
+# rule-config 模板定位 skill 自包含化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** rule-config 的规则/配置模板定位从"写死的三级客户端路径"改为"脚本自身所在 skill 目录（`SKILL_DIR`）单源唯一定位"，缺件即失败关闭；删除 marketplace/local/glob 全部外部候选。
+
+**Architecture:** 引入模块级 `SKILL_DIR = Path(__file__).resolve().parent.parent` 常量；`locate_templates()` 重写为"SKILL_DIR/references/ 四件套 + openspec/config.yaml 成对校验，缺任一 TemplateError"；`_load_reference`/`_load_kernel_source` 改用同一常量。skill 包自包含：脚本、模板、references 同船分发。
+
+**Tech Stack:** Python 3（标准库 + PyYAML）、pytest、bash 生命周期套件。
+
+**Spec:** `openspec/changes/rule-config-self-contained-templates/`（proposal/design/specs/tasks —— 本计划只展开该契约）
+
+**OpenSpec 工作包映射：** Task 1 ↔ tasks.md 工作包 1（测试先行）；Task 2 ↔ 工作包 2（脚本实现）；Task 3 ↔ 工作包 3（文档对账）；Task 4 ↔ 工作包 4（全量验证）。
+
+## Global Constraints
+
+- 模板唯一定位：`SKILL_DIR/references/`；禁止任何 `~/.claude/plugins/` 等客户端路径候选与全局搜索回退。
+- 必备文件清单固定：`references/rules/` 下 `agent-routing-kernel.md`、`language.md`、`openspec-superpowers-workflow.md`、`document-storage.md`，及 `references/openspec/config.yaml`。缺任一 → `TemplateError`，非零退出、目标项目零写入、报告缺失清单与"请重新安装 skill"。
+- 模板定位不得依赖 `HOME` 环境变量。
+- `resolve()` 必须保留（软链安装解析到真实仓库）。
+- compute_plan 的 `TemplateError → plan["failure"]` 与 step_s2 的报告回填语义不变（调用点不改）。
+- 测试运行目录：`cadence-init/skills/rule-config/`；pytest `uv run --with pytest python3 -m pytest tests/test_rule_config.py -q`；shell `bash tests/verify-managed-lifecycle.sh`。
+- 提交信息遵循仓库既有风格。
+
+---
+
+### Task 1: 测试改写（pytest 重写 + shell 反转 + 回归用例）
+
+**映射：** tasks.md 1.1/1.2/1.3；spec「模板与脚本必须同源」三个 scenario。
+
+**Files:**
+- Test: `cadence-init/skills/rule-config/tests/test_rule_config.py`（替换 `TestLocateTemplates` 整类，约 1078-1251 行）
+- Test: `cadence-init/skills/rule-config/tests/verify-managed-lifecycle.sh`（C16e 约 1471-1489 行；ONLINE_TEMPLATE_SKILL fixture 约 106-108 行）
+
+**Interfaces:**
+- Consumes: 现有 `rc.locate_templates() -> (rules_root: Path, openspec_yaml: Path)`、`rc.TemplateError`、测试工具 `mock`/`tempfile`/`os`（模块已导入）。
+- Produces（Task 2 实现的对照契约）: `rc.SKILL_DIR: Path` 模块级常量；`locate_templates()` 返回 `SKILL_DIR/references/rules` 与 `SKILL_DIR/references/openspec/config.yaml`；缺件时 `TemplateError` 消息含每个缺失的相对路径与"重新安装"字样。
+
+- [ ] **Step 1: 重写 `TestLocateTemplates` 整类（红）**
+
+整个类（`class TestLocateTemplates` 到下一个 class 之前，含 setUp 与全部八个用例）替换为：
+
+```python
+class TestLocateTemplates(unittest.TestCase):
+    """ut-locate_templates-* / skill 自包含单源定位契约（S1b 重构）。"""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def _make_skill_dir(self, missing=()):
+        """构造完整 skill 目录 fixture：<root>/skill/，可按 missing 缺件。"""
+        skill = self.root / "skill"
+        rules = skill / "references" / "rules"
+        rules.mkdir(parents=True)
+        for name in ("agent-routing-kernel.md", "language.md",
+                     "openspec-superpowers-workflow.md", "document-storage.md"):
+            if name not in missing:
+                (rules / name).write_text(f"tpl:{name}\n", encoding="utf-8")
+        (skill / "references" / "openspec").mkdir(parents=True)
+        if "config.yaml" not in missing:
+            (skill / "references" / "openspec" / "config.yaml").write_text(
+                "schema: spec-driven\n", encoding="utf-8"
+            )
+        return skill
+
+    def test_skill_dir_templates_preferred(self):
+        """ut-locate_templates-skill-dir / S1b-01（skill 目录完整 → 以其 references 为唯一模板源）"""
+        skill = self._make_skill_dir()
+        with mock.patch.object(rc, "SKILL_DIR", skill):
+            rules_root, openspec_yaml = rc.locate_templates()
+        self.assertEqual(rules_root, skill / "references" / "rules")
+        self.assertEqual(
+            openspec_yaml, skill / "references" / "openspec" / "config.yaml"
+        )
+
+    def test_missing_files_raise_template_error_with_list(self):
+        """ut-locate_templates-incomplete / S1b-02（缺件 → TemplateError 且列出缺失清单与重装建议）"""
+        skill = self._make_skill_dir(missing=("document-storage.md", "config.yaml"))
+        with mock.patch.object(rc, "SKILL_DIR", skill):
+            with self.assertRaises(rc.TemplateError) as ctx:
+                rc.locate_templates()
+        msg = str(ctx.exception)
+        self.assertIn("document-storage.md", msg)
+        self.assertIn("config.yaml", msg)
+        self.assertIn("重新安装", msg)
+
+    def test_no_home_dependency(self):
+        """ut-locate_templates-no-home / S1b-03（HOME 为空目录仍命中 skill 目录）"""
+        skill = self._make_skill_dir()
+        empty_home = self.root / "empty-home"
+        empty_home.mkdir()
+        with mock.patch.object(rc, "SKILL_DIR", skill), \
+                mock.patch.dict(os.environ, {"HOME": str(empty_home)}):
+            rules_root, _ = rc.locate_templates()
+        self.assertEqual(rules_root, skill / "references" / "rules")
+
+    def test_stale_marketplace_copy_ignored(self):
+        """ut-locate_templates-ignore-stale-marketplace / 回归（naruto 事故场景）：
+        过期 marketplace 副本存在且内容不同，仍取 skill 目录模板。"""
+        skill = self._make_skill_dir()
+        stale_home = self.root / "home"
+        mkt_rules = (
+            stale_home / ".claude" / "plugins" / "marketplaces"
+            / "cadence-skills-marketplace" / "cadence-init" / "skills"
+            / "rule-config" / "references" / "rules"
+        )
+        mkt_rules.mkdir(parents=True)
+        for name in ("agent-routing-kernel.md", "language.md",
+                     "openspec-superpowers-workflow.md", "document-storage.md"):
+            (mkt_rules / name).write_text("旧模板内容\n", encoding="utf-8")
+        (mkt_rules.parent.parent / "openspec").mkdir(parents=True)
+        (mkt_rules.parent.parent / "openspec" / "config.yaml").write_text(
+            "schema: spec-driven\n", encoding="utf-8"
+        )
+        with mock.patch.object(rc, "SKILL_DIR", skill), \
+                mock.patch.dict(os.environ, {"HOME": str(stale_home)}):
+            rules_root, _ = rc.locate_templates()
+        self.assertEqual(rules_root, skill / "references" / "rules")
+        self.assertNotEqual(str(rules_root), str(mkt_rules))
+```
+
+- [ ] **Step 2: 运行确认红**
+
+Run: `cd cadence-init/skills/rule-config && uv run --with pytest python3 -m pytest tests/test_rule_config.py::TestLocateTemplates -q`
+Expected: FAIL（`rc.SKILL_DIR` 不存在 → patch AttributeError / 新契约未实现）。其余测试类不受影响。
+
+- [ ] **Step 3: shell C16e 语义反转（红）**
+
+`verify-managed-lifecycle.sh` C16e 段（约 1471-1489 行）整段替换为：
+
+```bash
+# C16e. 空 HOME 仍可运行——模板来自 skill 目录，不依赖 HOME（it-s2-skill-self-contained / §11.5）。
+# 2026-08-19 语义反转：旧契约为「候选全缺 → 失败关闭」；新契约（skill 自包含）下 HOME 无关。
+case_root="$TEST_ROOT/fx-templates-missing"
+mkdir -p "$case_root"
+printf '# placeholder\n' > "$case_root/README.md"
+fake_home="$TEST_ROOT/fake-home-empty"
+mkdir -p "$fake_home"
+REPORT="$(mktemp /tmp/rule-config-report.XXXXXX)"
+set +e
+HOME="$fake_home" "$(command -v python3)" "$SCRIPT" apply --project-root "$case_root" --report "$REPORT" --no-interrupt >/dev/null 2>&1
+RUN_STATUS=$?
+set -e
+if [ "$RUN_STATUS" -eq 0 ] \
+  && ! jqr "['overall']" 2>/dev/null | grep -qix 'fail'; then
+  record_result it-s2-skill-self-contained "$RUN_STATUS" "-" "-" pass
+else
+  record_result it-s2-skill-self-contained "$RUN_STATUS" "-" "-" fail
+fi
+```
+
+- [ ] **Step 4: shell 删除 ONLINE_TEMPLATE_SKILL fixture（约 106-108 行）**
+
+删除三行 fixture 搭建。先 `grep -n 'ONLINE_TEMPLATE_SKILL\|TEST_HOME' tests/verify-managed-lifecycle.sh` 确认无其他引用；若 `TEST_HOME` 仍被别处使用则保留其定义，仅删 marketplace 铺陈三行。
+
+- [ ] **Step 5: 运行确认红**
+
+Run: `bash tests/verify-managed-lifecycle.sh`
+Expected: `it-s2-skill-self-contained` FAIL（旧脚本在空 HOME 下 TemplateError、非零退出）；其余 pass。
+
+- [ ] **Step 6: Commit（测试红态快照）**
+
+```bash
+git add cadence-init/skills/rule-config/tests/
+git commit -m "test(rule-config): 模板定位 skill 自包含契约测试（红态）"
+```
+
+---
+
+### Task 2: 脚本实现（SKILL_DIR 常量 + locate_templates 单源重写）
+
+**映射：** tasks.md 2.1/2.2；spec「模板与脚本必须同源」requirement。
+
+**Files:**
+- Modify: `cadence-init/skills/rule-config/scripts/rule-config.py`（常量区 ~417-432；`_load_reference` ~236-243；`_load_kernel_source` ~1926-1934；`locate_templates` 全体 ~1784-1860 及其辅助）
+
+**Interfaces:**
+- Consumes: Task 1 的测试契约。
+- Produces: `SKILL_DIR`（Path）、新 `locate_templates()`；删除 `_ONLINE_RULES_SUBPATH`、`_OFFLINE_RULES_SUBPATH`、`_FALLBACK_GLOB_PATTERN`、`TEMPLATE_REQUIRED_FALLBACK`、`_format_template_failures` 及三级定位全部代码。
+
+- [ ] **Step 1: 引入 `SKILL_DIR` 并统一三件套清单**
+
+在常量区（`TEMPLATE_REQUIRED` 附近）：
+
+```python
+# skill 自包含唯一定位基准：脚本自身所在 skill 目录（软链经 resolve 解析到真实仓库）。
+SKILL_DIR = Path(__file__).resolve().parent.parent
+```
+
+将 `TEMPLATE_REQUIRED` 扩为四件套并删除 `TEMPLATE_REQUIRED_FALLBACK`：
+
+```python
+TEMPLATE_REQUIRED = (
+    "agent-routing-kernel.md",
+    "language.md",
+    "openspec-superpowers-workflow.md",
+    "document-storage.md",
+)
+```
+
+- [ ] **Step 2: `locate_templates()` 重写**
+
+删除旧实现全体（含在线/离线/glob 逻辑与 `_format_template_failures`、候选校验辅助），替换为：
+
+```python
+def locate_templates() -> tuple:
+    """模板定位：skill 自包含单源（契约「模板与脚本必须同源」）。
+
+    唯一候选：SKILL_DIR/references/（rules/ 四件套 + openspec/config.yaml）。
+    缺失任一 → TemplateError（列出缺失清单与重装建议）；不降级到任何外部路径。
+    """
+    references = SKILL_DIR / "references"
+    rules_root = references / "rules"
+    openspec_yaml = references / "openspec" / "config.yaml"
+    missing = [
+        f"references/rules/{name}"
+        for name in TEMPLATE_REQUIRED
+        if not (rules_root / name).is_file()
+    ]
+    if not openspec_yaml.is_file():
+        missing.append("references/openspec/config.yaml")
+    if missing:
+        raise TemplateError(
+            "skill 安装不完整（缺少模板文件）：\n  - "
+            + "\n  - ".join(missing)
+            + "\n请重新安装 skill 后重试。"
+        )
+    return rules_root, openspec_yaml
+```
+
+同时删除 `_ONLINE_RULES_SUBPATH`/`_OFFLINE_RULES_SUBPATH`/`_FALLBACK_GLOB_PATTERN` 常量与 `_format_template_failures` 等只被旧实现引用的辅助函数。
+
+- [ ] **Step 3: 两处 loader 改用 `SKILL_DIR`**
+
+`_load_reference` 与 `_load_kernel_source` 中的 `skill_dir = Path(__file__).resolve().parent.parent` 改为直接使用 `SKILL_DIR` 常量。
+
+- [ ] **Step 4: 运行确认绿**
+
+Run: `uv run --with pytest python3 -m pytest tests/test_rule_config.py -q && bash tests/verify-managed-lifecycle.sh`
+Expected: pytest 全量 PASS（含 TestLocateTemplates 四新用例）；shell 全量 pass（含 `it-s2-skill-self-contained`）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cadence-init/skills/rule-config/scripts/rule-config.py
+git commit -m "feat(rule-config): 模板定位改为 skill 自包含单源，删除写死的客户端路径"
+```
+
+---
+
+### Task 3: 文档与对账
+
+**映射：** tasks.md 3.1/3.2/3.3。
+
+**Files:**
+- Modify: `cadence-init/skills/rule-config/SKILL.md`（第一步——定位脚本）
+- Modify: `cadence-init/skills/rule-config/references/merge-semantics.md`（§11.5）
+- Modify: `cadence-init/skills/rule-config/tests/skill-clause-map.md`（S1b-01~04 行）
+
+- [ ] **Step 1: SKILL.md 第一步改写**
+
+"**第一步——定位脚本（与 pre-check 同款约定）**"整段改为：
+
+```markdown
+**第一步——定位脚本**：脚本是本 rule-config skill 的关联脚本，即本 SKILL 所在目录的 `scripts/rule-config.py`（各客户端按其 skill 安装位置定位该目录，如 `<skill 安装根>/cadence-init/skills/rule-config/`）。模板与脚本同包（skill 自包含），由脚本自动解析其 skill 目录下的 `references/`，Agent 不做模板定位。脚本只读，不要 `cd` 进 skill 目录，也不要把脚本复制到别处执行。若脚本报"skill 安装不完整"，重新安装 skill 后重试，不得从其他项目或安装位置复制模板补齐。
+```
+
+- [ ] **Step 2: merge-semantics.md §11.5 整节重写**
+
+```markdown
+### 11.5 模板定位（skill 自包含）
+
+模板根路径与 OpenSpec 配置模板路径 MUST 以脚本自身所在 skill 目录（`SKILL_DIR`，`Path(__file__).resolve().parent.parent`）为唯一来源：`SKILL_DIR/references/rules/` 与 `SKILL_DIR/references/openspec/config.yaml`。禁止引用 `~/.claude/plugins/` 等客户端目录候选或全局搜索回退；模板定位 MUST NOT 依赖 `HOME` 环境变量。
+
+**成对校验**：`references/rules/` 下必须存在 `agent-routing-kernel.md`、`language.md`、`openspec-superpowers-workflow.md`、`document-storage.md` 四件套，且 `references/openspec/config.yaml` 必须存在；缺任一即 `TemplateError` 失败关闭（非零退出、目标项目零写入），报告逐个列出缺失文件名并给出"skill 安装不完整，请重新安装"恢复建议（对应测试 `ut-locate_templates-incomplete`；空 HOME 正常运行为 `it-s2-skill-self-contained`）。
+```
+
+§12 追加对账记录：`2026-08-19 定位自包含化对账（change rule-config-self-contained-templates）：模板三级定位（在线/离线/glob）删除，改为 skill 目录单源；it-s2-templates-missing 反转为 it-s2-skill-self-contained；TestLocateTemplates 六用例重写为 ut-locate_templates-skill-dir/-incomplete/-no-home/-ignore-stale-marketplace。`
+
+- [ ] **Step 3: skill-clause-map.md 同步**
+
+S1b-01~04 行改为单源语义与上述测试 ID；头部追加 2026-08-19 变更记录。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cadence-init/skills/rule-config/SKILL.md cadence-init/skills/rule-config/references/merge-semantics.md cadence-init/skills/rule-config/tests/skill-clause-map.md
+git commit -m "docs(rule-config): 定位规则与合并语义对账为 skill 自包含"
+```
+
+---
+
+### Task 4: 全量验证 + 过期 marketplace 共存 E2E
+
+**映射：** tasks.md 4.1/4.2/4.3。
+
+- [ ] **Step 1: pytest 全量**
+
+Run: `cd cadence-init/skills/rule-config && uv run --with pytest python3 -m pytest tests/test_rule_config.py -q`
+Expected: 全量 PASS。
+
+- [ ] **Step 2: shell 全量**
+
+Run: `bash tests/verify-managed-lifecycle.sh`
+Expected: SUMMARY 全 pass 0 fail。
+
+- [ ] **Step 3: E2E——过期 marketplace 共存环境**
+
+```bash
+E2E=$(mktemp -d)
+# 伪造过期 marketplace：模板 document-storage 为旧版（无产物路径覆盖）
+mkdir -p "$E2E/home/.claude/plugins/marketplaces/cadence-skills-marketplace/cadence-init/skills/rule-config/references/rules"
+grep -v -A8 '产物路径覆盖' /home/michaelche/.agents/Cadence-skills/cadence-init/skills/rule-config/references/rules/document-storage.md > "$E2E/home/.claude/plugins/marketplaces/cadence-skills-marketplace/cadence-init/skills/rule-config/references/rules/document-storage.md" || true
+# 项目：预置与旧模板一致的 document-storage.md（旧契约下会被误判幂等）
+mkdir -p "$E2E/proj/.claude/rules"
+cp "$E2E/home/.claude/plugins/marketplaces/cadence-skills-marketplace/cadence-init/skills/rule-config/references/rules/document-storage.md" "$E2E/proj/.claude/rules/document-storage.md"
+# 用仓库 skill 目录的脚本执行（HOME 指向伪 marketplace 环境）
+HOME="$E2E/home" python3 cadence-init/skills/rule-config/scripts/rule-config.py apply --project-root "$E2E/proj" --report "$E2E/r.json" --no-interrupt
+# 断言：document-storage.md 被覆盖为 skill 目录（含产物路径覆盖）版本且已归档
+grep -q '产物路径覆盖' "$E2E/proj/.claude/rules/document-storage.md"
+ls "$E2E/proj/cadence/legacy"/*/.claude/rules/document-storage.md
+```
+
+Expected: grep 命中；归档存在；退出码 0。
+
+- [ ] **Step 4: 收尾提交（如有修复）**
+
+```bash
+git add -A && git commit -m "test(rule-config): skill 自包含定位全量验证与 E2E"
+```
+
+---
+
+## Self-Review 记录
+
+- **Spec coverage**：requirement「模板与脚本必须同源」三 scenario ↔ Task 1 三个 pytest 用例 + shell 反转用例 + Task 4 E2E；无遗漏。
+- **Placeholder 扫描**：无 TBD；测试与实现代码完整。
+- **类型一致性**：`SKILL_DIR` 常量名、四件套清单、TemplateError 消息关键词（"重新安装"）在 Task 1（断言）与 Task 2（实现）间逐字一致。
+- **中间态**：Task 1 红态提交仅含测试；Task 2 绿态后双套件全绿。

--- a/openspec/changes/rule-config-self-contained-templates/.openspec.yaml
+++ b/openspec/changes/rule-config-self-contained-templates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/rule-config-self-contained-templates/design.md
+++ b/openspec/changes/rule-config-self-contained-templates/design.md
@@ -1,0 +1,60 @@
+# Design: rule-config-self-contained-templates
+
+## Context
+
+现状与动机见 proposal.md。设计相关的当前状态：
+
+- `rule-config.py` 中 `_load_reference`/`_load_kernel_source` 已用 `Path(__file__).resolve().parent.parent`（script-relative），但 `locate_templates()` 保持旧三级定位（在线 marketplace → 离线 local → glob 回退，在线命中即短路）。
+- pytest `TestLocateTemplates` 六用例通过伪造 HOME 测三级行为；shell `it-s2-templates-missing`（C16e）用空 HOME 触发全缺失败；`ONLINE_TEMPLATE_SKILL` fixture（106-108 行）往 fake HOME 铺 marketplace 布局。
+- naruto 事故现场：pi 调用 `~/.agents/Cadence-skills` 新脚本，模板却被短路过期的 `~/.claude` marketplace checkout。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 模板与脚本同源：模板唯一定位 `SKILL_DIR/references/`，与客户端无关。
+- 删除全部写死的客户端路径候选与全局搜索回退。
+- skill 包不完整时显式失败关闭并给出可操作的恢复建议。
+- 空 HOME 环境照常工作（回归断言）。
+
+**Non-Goals:**
+
+- 不改模板成对校验的文件清单与 TemplateError 的失败关闭性质。
+- 不动 pre-check 的 Superpowers 外部依赖路径、skill-creator 安装目标。
+- 不引入"多候选择优"逻辑（mtime 等）——单源即契约，无需择优。
+
+## Decisions
+
+### D1：单源唯一定位，删除全部回退档位
+
+模板只从 `SKILL_DIR/references/` 取。原则：skill 包自包含，任何"去别处找"的行为都会引入跨安装污染（naruto 事故的根因）。替代方案"保留旧档位作兜底"被否决——兜底即漏洞：兜底命中过期副本时静默错误，比显式失败更糟；且脚本与 references 同船分发，正常安装下单源必然命中。
+
+### D2：模块级 `SKILL_DIR` 常量统一三处引用
+
+`SKILL_DIR = Path(__file__).resolve().parent.parent`。`resolve()` 使软链安装（如 `~/.agents/skills/<name>` → 真实仓库）正确落位；`_load_reference`/`_load_kernel_source` 改为引用常量，消除重复表达式。测试经 `mock.patch.object(rc, "SKILL_DIR", ...)` 注入 fixture 路径即可隔离。
+
+### D3：不完整即失败关闭，而非顺延
+
+必备文件清单（四件套 + `openspec/config.yaml`）缺失任一 → `TemplateError`，列出缺失清单与重装建议。不修不补不猜测——部分复制的 skill 包是安装缺陷，必须用显式失败暴露，而不是用别源内容掩盖。
+
+### D4：测试语义反转而非删除
+
+- pytest：六用例全删重写为单源契约（完整命中 / 缺件失败 / 空 HOME 无依赖）。
+- shell C16e（`it-s2-templates-missing`）反转为正断言：空 HOME 下流程仍正常完成（模板来自 skill 目录）——把旧失败场景变成新契约的回归断言。`ONLINE_TEMPLATE_SKILL` fixture 删除。
+- E2E 回归：fake marketplace 旧模板 + skill 目录新模板共存，断言项目文件按 skill 目录模板收敛。
+
+## Risks / Trade-offs
+
+- **Claude Code 极端环境**：若某客户端把 skill 拆包安装（scripts 与 references 分离），单源会失败——但该布局本就违反"skill 包自包含"前提，SKILL.md 已声明"不得复制脚本单独执行"。失败信息会指引重装。 → 接受。
+- **既有 shell fixture 语义变化**：`ONLINE_TEMPLATE_SKILL` 删除后 C16e 改为正断言 → 审查时重点核对。
+- **调试场景失去 glob 便利**（在任意目录放个模板就能跑）→ 该便利正是污染源，放弃。
+
+## Migration Plan
+
+1. 本 change 为仓库内代码/测试/文档变更，TDD 实施。
+2. 框架用户无需迁移：正常安装的 skill 包天然自包含，行为只会更正（模板与版本同步）。
+3. 回滚：git 回滚实现提交即可，目标项目无持久状态。
+
+## Open Questions
+
+无。

--- a/openspec/changes/rule-config-self-contained-templates/proposal.md
+++ b/openspec/changes/rule-config-self-contained-templates/proposal.md
@@ -1,0 +1,40 @@
+# Proposal: rule-config-self-contained-templates
+
+## Why
+
+rule-config 的模板定位（`locate_templates`）与脚本/内核定位不对称：内核走 script-relative（skill 目录），模板却写死优先查 `~/.claude/plugins/marketplaces/` 下的 Claude 插件目录并短路返回。在非 Claude 客户端（pi）环境中，若该插件目录存在但过期（停留在旧提交），模板比对会以旧模板为准——最新 skill 安装的模板更新被静默跳过。naruto 实测：新脚本 + 旧 marketplace 模板的组合导致 `document-storage.md` 缺新章节却被判定"幂等跳过"，全程无报错无提示。
+
+用户裁决的原则：**skill 包自包含**——脚本、模板、references 全部以"脚本自身所在 skill 目录"为唯一权威源；定位失败就失败关闭并报告安装不完整，绝不去别处找副本。
+
+## What Changes
+
+- **`locate_templates()` 重写为单源定位**：唯一候选 `SKILL_DIR/references/`（`SKILL_DIR = Path(__file__).resolve().parent.parent`，软链经 `resolve()` 解析到真实仓库）；成对校验（rules 三件套 + `document-storage.md` + `openspec/config.yaml`）缺失任一 → `TemplateError` 失败关闭、非零退出、目标项目零写入、报告缺失清单与"skill 安装不完整，请重新安装"。**BREAKING**（定位语义）
+- **删除写死的客户端路径**：移除 `_ONLINE_RULES_SUBPATH`（cadence-skills-marketplace）、`_OFFLINE_RULES_SUBPATH`（cadence-skills-local）、`_FALLBACK_GLOB_PATTERN` 及全部三级定位逻辑。
+- **统一 `SKILL_DIR` 常量**：`_load_reference` / `_load_kernel_source` / `locate_templates` 共用，消除三处重复的 `Path(__file__).resolve().parent.parent`。
+- **SKILL.md 定位规则改写**：脚本即本 SKILL 所在目录的 `scripts/rule-config.py`；模板与脚本同包由脚本自动解析，Agent 不做模板定位；删除"plugin 缓存根/仓库安装根"候选表述。
+- **文档对账**：`references/merge-semantics.md` §11.5 整节重写为"skill 自包含唯一定位"；`tests/skill-clause-map.md` 的 S1b-01~04 行同步。
+- **测试语义反转**：shell `it-s2-templates-missing` 从"空 HOME 全缺 → 失败关闭"反转为"空 HOME 仍可运行（模板不依赖 HOME）"；pytest `TestLocateTemplates` 六用例全删重写为单源契约。
+
+### 非目标
+
+- 不改 pre-check 的 Superpowers 同步路径（`~/.agents/superpowers` 等外部依赖位置是功能本身）。
+- 不改 skill-creator 的安装目标语义（另一功能）。
+- 不改模板的成对校验文件清单与 TemplateError 的失败关闭性质（只改候选来源）。
+
+## Capabilities
+
+### New Capabilities
+
+（无新 capability。）
+
+### Modified Capabilities
+
+- `rule-config-scripted-execution`：新增"模板与脚本必须同源（skill 自包含）"requirement——模板唯一定位到脚本所在 skill 目录，禁用环境相关路径候选与全局搜索回退，缺失即失败关闭。
+
+## Impact
+
+- **代码**：`cadence-init/skills/rule-config/scripts/rule-config.py`（`locate_templates` 重写、`SKILL_DIR` 常量、删除三级定位常量与逻辑）。
+- **测试**：`tests/test_rule_config.py`（TestLocateTemplates 重写、新增 HOME 无依赖断言）；`tests/verify-managed-lifecycle.sh`（C16e 语义反转、删除 ONLINE_TEMPLATE_SKILL fixture）；`tests/skill-clause-map.md` 对账。
+- **文档**：`SKILL.md`（第一步定位规则）、`references/merge-semantics.md` §11.5。
+- **行为**：模板永远跟随当前调用的 skill 安装版本；过期 marketplace/缓存副本不再被误用；skill 安装不完整时立即显式失败而非静默使用别源模板。
+- **回归场景**：naruto 式环境（pi + `~/.agents` 新仓库 + 过期 Claude marketplace 共存）重跑 rule-config，`document-storage.md` 将被归档并覆盖补齐新章节。

--- a/openspec/changes/rule-config-self-contained-templates/specs/rule-config-scripted-execution/spec.md
+++ b/openspec/changes/rule-config-self-contained-templates/specs/rule-config-scripted-execution/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: 模板与脚本必须同源（skill 自包含）
+
+rule-config 的规则模板与 OpenSpec 配置模板 MUST 从脚本自身所在 skill 目录解析——以 `SKILL_DIR`（`Path(__file__).resolve().parent.parent`，软链经 `resolve()` 解析到真实安装位置）下的 `references/` 为唯一模板源，MUST NOT 使用任何与调用环境相关的固定路径候选（如 `~/.claude/plugins/` 下的 marketplace 目录）或全局文件系统搜索回退。skill 包（`SKILL.md` + `scripts/` + `references/`）MUST 视为自包含整体。
+
+必备模板文件清单固定为：`references/rules/` 下 `agent-routing-kernel.md`、`language.md`、`openspec-superpowers-workflow.md`、`document-storage.md`，以及 `references/openspec/config.yaml`。缺失任一时脚本 MUST 以 `TemplateError` 失败关闭：非零退出、目标项目零写入、报告列出每个缺失文件名与"skill 安装不完整，请重新安装"恢复建议。
+
+模板定位 MUST NOT 依赖 `HOME` 环境变量或客户端安装目录布局；脚本被任何客户端以任意安装根调用时，模板内容 MUST 始终与该调用来源的 skill 包版本一致。
+
+#### Scenario: 模板始终取自调用来源的 skill 目录
+
+- **WHEN** 脚本运行且其 skill 目录的 references 完整
+- **THEN** 模板源 MUST 为该 skill 目录的 `references/`
+- **AND** 即使其他安装位置（如过期的 marketplace checkout）存在内容不同的模板副本，MUST NOT 被选用
+
+#### Scenario: skill 目录模板不完整即失败关闭
+
+- **WHEN** skill 目录的必备模板文件缺失任一
+- **THEN** 脚本 MUST 以 `TemplateError` 非零退出且目标项目零写入
+- **AND** 报告 MUST 列出每个缺失文件名与"skill 安装不完整，请重新安装"恢复建议
+
+#### Scenario: 模板定位不依赖 HOME
+
+- **WHEN** `HOME` 环境变量指向空目录（无任何插件或缓存布局）
+- **THEN** 脚本 MUST 仍能以 skill 目录模板正常完成全部流程
+- **AND** 不得因固定路径候选缺失而失败

--- a/openspec/changes/rule-config-self-contained-templates/tasks.md
+++ b/openspec/changes/rule-config-self-contained-templates/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: rule-config-self-contained-templates
+
+## 1. 测试先行（TDD 红）
+
+- [ ] 1.1 重写 pytest `TestLocateTemplates`：删六用例，新增三用例——完整 skill 目录命中（patch `SKILL_DIR` 到完整 fixture）；缺件 `TemplateError` 且报告缺失清单；空 HOME 仍命中 skill 目录（映射「模板与脚本必须同源」全部三个 scenario）
+- [ ] 1.2 反转 shell `it-s2-templates-missing`（C16e）为正断言：空 HOME 下 apply 正常完成、overall 非 fail；删除 `ONLINE_TEMPLATE_SKILL` fixture 搭建
+- [ ] 1.3 新增 naruto 式回归用例：fake marketplace 旧模板 + skill 目录新模板共存，断言按 skill 目录模板收敛（映射「模板始终取自调用来源的 skill 目录」scenario）
+
+## 2. 脚本实现（TDD 绿）
+
+- [ ] 2.1 引入模块级 `SKILL_DIR` 常量；`_load_reference`/`_load_kernel_source` 改用常量
+- [ ] 2.2 重写 `locate_templates()` 为单源定位 + 成对校验 + `TemplateError`（缺失清单与重装建议）；删除 `_ONLINE_RULES_SUBPATH`/`_OFFLINE_RULES_SUBPATH`/`_FALLBACK_GLOB_PATTERN` 与三级逻辑
+
+## 3. 文档与对账
+
+- [ ] 3.1 重写 `SKILL.md` 第一步定位规则为 skill 自包含表述
+- [ ] 3.2 重写 `references/merge-semantics.md` §11.5 为单源定位契约
+- [ ] 3.3 同步 `tests/skill-clause-map.md` 的 S1b-01~04 行（三级定位 → 单源；it-s2-templates-missing 语义反转登记）
+
+## 4. 全量验证
+
+- [ ] 4.1 pytest 全量通过
+- [ ] 4.2 shell 生命周期套件全量通过
+- [ ] 4.3 E2E：模拟过期 marketplace 共存环境，验证模板按 skill 目录收敛且 `document-storage.md` 被归档+覆盖


### PR DESCRIPTION
## 变更内容

将 rule-config 的模板定位从"写死的 ~/.claude marketplace 三级定位（在线/离线/glob 回退）"重写为**脚本自身所在 skill 目录（`SKILL_DIR`）单源唯一定位**：模板与脚本永远同源同版本，四件套 + openspec/config.yaml 缺件即 `TemplateError` 失败关闭并列出缺失清单；删除全部外部路径候选与全局搜索回退。

**动机**：naruto 实测事故——pi 调用 `~/.agents` 新脚本，模板却被短路过期的 Claude marketplace checkout（#84），导致 `document-storage.md` 缺新章节被误判"幂等跳过"，全程无报错。

## 契约与计划

- OpenSpec change：`openspec/changes/rule-config-self-contained-templates/`（validate --strict 通过）
- 实施 Plan：`cadence/plans/2026-08-19_计划文档_实施_rule-config模板定位skill自包含化_v1.0.md`

## 实现

- `locate_templates()` 单源重写；模块级 `SKILL_DIR` 常量统一 `_load_reference`/`_load_kernel_source`/`locate_templates` 三处
- 删除 `_ONLINE/_OFFLINE_RULES_SUBPATH`、`_FALLBACK_GLOB_PATTERN`、`_format_template_failures` 及全部三级定位代码（净 -236 行）
- SKILL.md 第一步定位规则、merge-semantics §11.5、clause-map S1b 行对账

## 验证

- pytest：210 passed（TestLocateTemplates 重写为 4 个单源契约用例，含 naruto 回归场景）
- shell 生命周期：pass=98 fail=0（C16e 反转为"空 HOME 照常运行"）
- E2E：伪造过期 marketplace 共存环境，document-storage.md 被正确归档+覆盖补齐
- 每任务独立审查 + 全分支终审（Ready to merge）

## 兼容性

- Claude Code marketplace 安装：脚本经 plugin 目录调用时 `Path(__file__).resolve()` 解析到实际安装位置，模板与脚本同版本——**消除在线/离线 checkout 过期漂移**。
- pi/其他客户端：纯改进——任意安装根可用，模板定位不再依赖 HOME。