### PR TITLE
docs(mcp): 智普 MCP 规则增量优化（A-narrow）

### DIFF
--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -126,6 +126,9 @@ codegraph serve --mcp
 1. 图片建议放到本地目录，通过对话指定图片名称或路径来调用
 2. 直接在客户端粘贴图片无法调用此 MCP（Claude Code 除外；pi 经 pi-mcp-adapter 调用时同样需通过本地路径指定图片）
 3. 需要安装最新版本（>= 0.1.2）
+4. 前提：Node.js 版本需 >= 18
+5. `npx` 可能命中旧缓存；排障时可一次性使用 `@z_ai/mcp-server@latest` 或清理 npx 缓存，配置中的 args 保持不变
+6. `Z_AI_MODE` 可选 `ZHIPU` 或 `ZAI`，本模板固定为 `ZHIPU`
 
 **典型工作流**：
 ```
@@ -192,6 +195,7 @@ codegraph serve --mcp
 **使用规则**：
 1. 基于 HTTP 协议的远程服务，无需本地安装运行时
 2. 返回结构化数据，包含标题、正文、元数据等
+3. 目标站点有反爬或登录墙时可能抓取失败，属预期结果，不要反复重试
 
 **典型工作流**：
 ```
@@ -226,6 +230,7 @@ codegraph serve --mcp
 **使用规则**：
 1. 基于 HTTP 协议的远程服务（基于 zread.ai），无需本地安装运行时
 2. 支持搜索文档、浏览结构、读取代码三种操作
+3. 仅支持公开 GitHub 仓库，且需已被 zread.ai 收录；未收录仓库查询失败属预期
 
 **典型工作流**：
 ```
@@ -241,6 +246,11 @@ codegraph serve --mcp
 # 排查 Issue
 > 搜索 prisma/prisma 仓库中关于连接池超时的 Issue
 ```
+
+### 智普 MCP 通用说明（可选）
+
+1. SSE 备用端点为 `https://open.bigmodel.cn/api/mcp/<name>/sse?Authorization=<KEY>`（`web_search_prime`、`web_reader`、`zread`），仅在 HTTP 端点不可用时临时排障使用；密钥出现在 URL 中会落入日志与 shell 历史，不得写入默认配置。
+2. Claude Code + GLM Coding Plan 场景下，服务端已内置联网搜索、网页读取和 `image_analysis`，可能与本地四个 server 的工具重复，可按需禁用；Codex、pi、Kimi 无内置能力，默认仍需这四个 server。
 
 ### MiniMax Token Plan MCP（可选）
 
@@ -284,9 +294,10 @@ codegraph serve --mcp
 ### 智普/MiniMax API Key 安全提醒
 
 > **安全警告**
-> 1. 请自行前往对应平台获取 API Key，不要将真实密钥告诉 AI 客户端（Claude Code、Codex、pi 等）
+> 1. 请自行前往对应平台获取 API Key，不要将真实密钥告诉 AI 客户端（Claude Code、Codex、pi、Kimi 等）
 > 2. 配置文件中使用占位符，用户需自行替换为真实密钥
 > 3. `.mcp.json` 已在 `.gitignore` 中排除，不会提交到版本控制
+> 4. 团队版 Coding Plan Key 与智谱平台其他 API Key 不通用；使用团队额度必须使用团队套餐 Key，个人/团队 Key 获取入口不同。
 >
 > - 智普 API Key 获取地址：https://open.bigmodel.cn/usercenter/apikeys
 > - MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-plan

--- a/cadence-init/skills/mcp-configuration/SKILL.md
+++ b/cadence-init/skills/mcp-configuration/SKILL.md
@@ -159,7 +159,7 @@ Server 名称使用精确名称匹配，不进行大小写归一化。`.mcp.json
 
 **使用方式**：
 1. 先调用 `mcp__context7__resolve-library-id` 解析库 ID
-2. 再调用 `mcp__context7__query-docs` 获取文档
+2. 再调用 `mcp__context7__get-library-docs` 获取文档
 
 **示例**：
 ```json
@@ -168,7 +168,7 @@ Server 名称使用精确名称匹配，不进行大小写归一化。`.mcp.json
 // 返回："/react/react"
 
 // 步骤2：获取文档
-{"libraryId": "/react/react", "query": "hooks"}
+{"context7CompatibleLibraryID": "/react/react", "topic": "hooks"}
 ```
 
 #### Sequential Thinking MCP
@@ -224,8 +224,11 @@ Server 名称使用精确名称匹配，不进行大小写归一化。`.mcp.json
 
 **使用规则**：
 1. 图片建议放到本地目录，通过对话指定图片名称或路径来调用
-2. 直接在客户端粘贴图片无法调用此 MCP（Claude Code 除外）
+2. 直接在客户端粘贴图片无法调用此 MCP（Claude Code 除外；pi 经 pi-mcp-adapter 调用时同样需通过本地路径指定图片）
 3. 需要安装最新版本（>= 0.1.2）
+4. 前提：Node.js 版本需 >= 18
+5. `npx` 可能命中旧缓存；排障时可一次性使用 `@z_ai/mcp-server@latest` 或清理 npx 缓存，配置中的 args 保持不变
+6. `Z_AI_MODE` 可选 `ZHIPU` 或 `ZAI`，本模板固定为 `ZHIPU`
 
 **典型工作流**：
 ```
@@ -407,10 +410,11 @@ Server 名称使用精确名称匹配，不进行大小写归一化。`.mcp.json
 
 ```
 ⚠️ API Key 安全提醒：
-1. 请自行前往对应平台获取 API Key，不要将真实密钥告诉 Claude Code
+1. 请自行前往对应平台获取 API Key，不要将真实密钥告诉 AI 客户端（Claude Code、Codex、pi、Kimi 等）
 2. 配置文件中使用占位符（如 your_zhipu_api_key），用户需自行替换为真实密钥
 3. .mcp.json 已在 .gitignore 中排除，不会提交到版本控制
 4. 建议使用环境变量管理密钥，避免明文存储
+5. 团队版 Coding Plan Key 与智谱平台其他 API Key 不通用；使用团队额度必须使用团队套餐 Key，个人/团队 Key 获取入口不同。
 
 智普 API Key 获取地址：https://open.bigmodel.cn/usercenter/apikeys
 MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-plan
@@ -478,6 +482,8 @@ MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-pla
 #### 智普 MCP 配置（默认添加占位）
 
 > 将以下配置合并到 `.mcp.json` 的 `mcpServers` 中，`your_zhipu_api_key` 需用户自行替换
+
+> 默认保持远程服务的 `type: "http"`。SSE 仅作 HTTP 端点不可用时的手动回退，不写入默认模板，因为密钥出现在 URL 中会落入日志与 shell 历史；`zai-mcp-server` 的 args 保持 `["-y", "@z_ai/mcp-server"]`，不加 `@latest`，避免触发同名 server 参数冲突合并。
 
 ```json
 {

--- a/cadence-init/skills/rule-config/references/rules/mcp-servers.md
+++ b/cadence-init/skills/rule-config/references/rules/mcp-servers.md
@@ -126,6 +126,9 @@ codegraph serve --mcp
 1. 图片建议放到本地目录，通过对话指定图片名称或路径来调用
 2. 直接在客户端粘贴图片无法调用此 MCP（Claude Code 除外；pi 经 pi-mcp-adapter 调用时同样需通过本地路径指定图片）
 3. 需要安装最新版本（>= 0.1.2）
+4. 前提：Node.js 版本需 >= 18
+5. `npx` 可能命中旧缓存；排障时可一次性使用 `@z_ai/mcp-server@latest` 或清理 npx 缓存，配置中的 args 保持不变
+6. `Z_AI_MODE` 可选 `ZHIPU` 或 `ZAI`，本模板固定为 `ZHIPU`
 
 **典型工作流**：
 ```
@@ -192,6 +195,7 @@ codegraph serve --mcp
 **使用规则**：
 1. 基于 HTTP 协议的远程服务，无需本地安装运行时
 2. 返回结构化数据，包含标题、正文、元数据等
+3. 目标站点有反爬或登录墙时可能抓取失败，属预期结果，不要反复重试
 
 **典型工作流**：
 ```
@@ -226,6 +230,7 @@ codegraph serve --mcp
 **使用规则**：
 1. 基于 HTTP 协议的远程服务（基于 zread.ai），无需本地安装运行时
 2. 支持搜索文档、浏览结构、读取代码三种操作
+3. 仅支持公开 GitHub 仓库，且需已被 zread.ai 收录；未收录仓库查询失败属预期
 
 **典型工作流**：
 ```
@@ -241,6 +246,11 @@ codegraph serve --mcp
 # 排查 Issue
 > 搜索 prisma/prisma 仓库中关于连接池超时的 Issue
 ```
+
+### 智普 MCP 通用说明（可选）
+
+1. SSE 备用端点为 `https://open.bigmodel.cn/api/mcp/<name>/sse?Authorization=<KEY>`（`web_search_prime`、`web_reader`、`zread`），仅在 HTTP 端点不可用时临时排障使用；密钥出现在 URL 中会落入日志与 shell 历史，不得写入默认配置。
+2. Claude Code + GLM Coding Plan 场景下，服务端已内置联网搜索、网页读取和 `image_analysis`，可能与本地四个 server 的工具重复，可按需禁用；Codex、pi、Kimi 无内置能力，默认仍需这四个 server。
 
 ### MiniMax Token Plan MCP（可选）
 
@@ -284,9 +294,10 @@ codegraph serve --mcp
 ### 智普/MiniMax API Key 安全提醒
 
 > **安全警告**
-> 1. 请自行前往对应平台获取 API Key，不要将真实密钥告诉 AI 客户端（Claude Code、Codex、pi 等）
+> 1. 请自行前往对应平台获取 API Key，不要将真实密钥告诉 AI 客户端（Claude Code、Codex、pi、Kimi 等）
 > 2. 配置文件中使用占位符，用户需自行替换为真实密钥
 > 3. `.mcp.json` 已在 `.gitignore` 中排除，不会提交到版本控制
+> 4. 团队版 Coding Plan Key 与智谱平台其他 API Key 不通用；使用团队额度必须使用团队套餐 Key，个人/团队 Key 获取入口不同。
 >
 > - 智普 API Key 获取地址：https://open.bigmodel.cn/usercenter/apikeys
 > - MiniMax API Key 获取地址：https://platform.minimaxi.com/subscribe/token-plan

--- a/cadence-init/skills/rule-config/tests/verify-managed-lifecycle.sh
+++ b/cadence-init/skills/rule-config/tests/verify-managed-lifecycle.sh
@@ -1939,14 +1939,31 @@ else
   record_result sc-l1-source-copy-sync 1 same diff fail
 fi
 
-# D7. 仓库根 openspec/config.yaml 不得含 rules.apply（sc-no-rules-apply）
+# D7. 框架规则权威模板与仓库根副本同步（sc-framework-rule-source-copy-sync）
+framework_rules_sync_status=0
+for f in language.md document-storage.md markdown-format.md mcp-servers.md code-reading.md playwright.md; do
+  if ! diff -q "$SKILL_DIR/references/rules/$f" "$REPO_ROOT/.claude/rules/$f" >/dev/null 2>&1; then
+    framework_rules_sync_status=1
+  fi
+done
+if ! diff -q "$SKILL_DIR/references/rules/code-usage-noncoding.md" \
+           "$REPO_ROOT/.claude/rules/code-usage.md" >/dev/null 2>&1; then
+  framework_rules_sync_status=1
+fi
+if [ "$framework_rules_sync_status" -eq 0 ]; then
+  record_result sc-framework-rule-source-copy-sync 0 same same pass
+else
+  record_result sc-framework-rule-source-copy-sync 1 same diff fail
+fi
+
+# D8. 仓库根 openspec/config.yaml 不得含 rules.apply（sc-no-rules-apply）
 if python3 -c "import yaml;d=yaml.safe_load(open('$REPO_ROOT/openspec/config.yaml'));assert 'apply' not in (d.get('rules') or {})" 2>/dev/null; then
   record_result sc-no-rules-apply 0 absent absent pass
 else
   record_result sc-no-rules-apply 1 absent present fail
 fi
 
-# D8. L0 引用的规则文件存在性（sc-l0-rule-refs-exist）：提取 CLAUDE.md L0 区块内 .claude/rules/*.md 引用逐一 test -f
+# D9. L0 引用的规则文件存在性（sc-l0-rule-refs-exist）：提取 CLAUDE.md L0 区块内 .claude/rules/*.md 引用逐一 test -f
 if python3 - "$REPO_ROOT/CLAUDE.md" <<'EOF'
 import re,sys,os
 text=open(sys.argv[1]).read()
@@ -1960,14 +1977,14 @@ else
   record_result sc-l0-rule-refs-exist 1 none missing fail
 fi
 
-# D9. 瘦身 SKILL 不得含直接读写目标项目文件的操作指令（sc-no-direct-target-writes）
+# D10. 瘦身 SKILL 不得含直接读写目标项目文件的操作指令（sc-no-direct-target-writes）
 if ! grep -qE '读取内容，写入项目的|将以下文件从.*写入' "$SKILL_MD"; then
   record_result sc-no-direct-target-writes 0 absent absent pass
 else
   record_result sc-no-direct-target-writes 1 absent present fail
 fi
 
-# D10. 脚本 PRUNE_DIRS 与 SKILL.md find 剪枝清单一致（sc-prune-dirs-contract）。
+# D11. 脚本 PRUNE_DIRS 与 SKILL.md find 剪枝清单一致（sc-prune-dirs-contract）。
 # codex 终审 I6：修复 map() 误用导致的检查恒失败，且失败计入 fail（不再假绿）。
 if assert_bounded_source_scan_contract; then
   record_result sc-prune-dirs-contract 0 consistent consistent pass


### PR DESCRIPTION
## 背景

对照智谱官方最新文档（[vision](https://docs.bigmodel.cn/cn/coding-plan/mcp/vision-mcp-server) / [search](https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server) / [reader](https://docs.bigmodel.cn/cn/coding-plan/mcp/reader-mcp-server) / [zread](https://docs.bigmodel.cn/cn/coding-plan/mcp/zread-mcp-server)）核查智普 MCP 接入方案。

**结论：四个 server 的端点、认证、名称均与官方一致，无配置级变更。** 本次为纯文档增量（oracle 决策方案 A-narrow），不改任何端点/args/env，不新建 OpenSpec change。

## 改动内容

### 1. 规则模板 `cadence-init/skills/rule-config/references/rules/mcp-servers.md`（+ 副本 `.claude/rules/mcp-servers.md`）
- 视觉理解追加：Node.js >= 18；npx 旧缓存排障（一次性 `@z_ai/mcp-server@latest`，配置 args 不变）；`Z_AI_MODE` 可选 ZHIPU/ZAI
- 网页读取追加：反爬/登录墙站点失败属预期，不反复重试
- ZRead 追加：仅支持公开 GitHub 仓库且需被 zread.ai 收录
- 新增「智普 MCP 通用说明（可选）」：SSE 备用端点仅临时排障（密钥入 URL 风险）；Claude Code + GLM Coding Plan 内置能力可按需禁用；Codex/pi/Kimi 默认仍需四 server
- API Key 安全提醒：团队版 Key 不通用；客户端枚举补 Kimi

### 2. `cadence-init/skills/mcp-configuration/SKILL.md`
- 修正事实错误：Context7 工具名 `mcp__context7__get-library-docs` 及参数 `context7CompatibleLibraryID`/`topic`
- 同步视觉理解新规则与 pi 表述；补 HTTP 默认/SSE 回退/不加 `@latest` 说明

### 3. `verify-managed-lifecycle.sh`
- 新增 `sc-framework-rule-source-copy-sync`：受管规则模板与 `.claude/rules/` 副本零漂移静态检查

## 验证
- `python3 -m unittest discover ...` → 219 passed
- `bash verify-managed-lifecycle.sh` → pass=99 fail=0（新增 1 项）
- 模板与副本 `cmp` 零差异；`bash -n`、`git diff --check` 干净
- reviewer 审核通过（0 blocker / 0 major / 1 minor 可接受）